### PR TITLE
Add expand/collapse all control

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,8 @@ fn main() {
         initial_validation_done: Arc::new(Mutex::new(false)), // Initialize flag to false
         registered_hotkeys: Arc::new(Mutex::new(HashMap::new())), // Initialize the map
         rename_dialog: None,
+        all_expanded: true,
+        expand_all_signal: None,
     };
 
     // Launch GUI and set the taskbar icon after creating the window

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -344,8 +344,9 @@ impl Workspace {
     pub fn validate_workspace(&mut self) {
         self.valid = {
             let hotkey_valid = self
-            .hotkey
-            .as_ref().is_some_and(|hotkey| is_valid_key_combo(&hotkey.key_sequence));
+                .hotkey
+                .as_ref()
+                .is_some_and(|hotkey| is_valid_key_combo(&hotkey.key_sequence));
             let any_valid_window = self.windows.iter().any(|window| unsafe {
                 IsWindow(HWND(window.id as *mut std::ffi::c_void)).as_bool()
             });
@@ -354,7 +355,7 @@ impl Workspace {
         };
     }
 }
-/// Presents egui UI elements for configuring **one** `Window`’s positioning data: 
+/// Presents egui UI elements for configuring **one** `Window`’s positioning data:
 /// its **Home** and **Target** coordinates, plus actions to **capture** or **move** the window.
 ///
 /// # Behavior


### PR DESCRIPTION
## Summary
- add `all_expanded` and `expand_all_signal` fields
- implement Expand/Collapse All button in header
- control header state using `CollapsingState`
- initialize new fields in `main`

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `/usr/bin/rustfmt src/gui.rs src/main.rs src/workspace.rs`
- `cargo clippy --target x86_64-pc-windows-gnu` *(fails: 'cargo-clippy' is not installed)*
- `/usr/bin/cargo-clippy -- --target x86_64-pc-windows-gnu` *(fails: requires newer rustc)*
- `cargo build --target x86_64-pc-windows-gnu` *(fails: target may not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c6b6fc1d48332ae0da1e5442c6abf