### PR TITLE
Support renaming workspaces

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -306,7 +306,7 @@ impl App {
                         state.set_open(expand);
                     }
 
-                    let (toggle_response, mut header_inner, _) = state
+                    let (_toggle_response, mut header_inner, _) = state
                         .show_header(ui, |ui| {
                             ui.label(header_text);
                         })

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -324,13 +324,10 @@ impl App {
                             self.render_workspace_controls(ui, workspace, &mut context);
                         });
 
-                    // Attach right-click context menu to the header for renaming
-                    header_inner.response.context_menu(|ui| {
-                        if ui.button("Rename").clicked() {
-                            self.rename_dialog = Some((i, workspace.name.clone()));
-                            ui.close_menu();
-                        }
-                    });
+                    // Open the rename dialog directly on right-click
+                    if header_inner.response.clicked_by(egui::PointerButton::Secondary) {
+                        self.rename_dialog = Some((i, workspace.name.clone()));
+                    }
                 }
             });
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -382,6 +382,9 @@ impl App {
                 if let Some(ws) = workspaces.get_mut(index) {
                     ws.name = name_buf;
                 }
+                drop(workspaces); // release lock before saving to avoid deadlocks
+                // Persist the updated name to disk
+                self.save_workspaces();
                 // Dialog stays closed
             } else if !close_dialog {
                 // User neither confirmed nor cancelled, so put dialog state back


### PR DESCRIPTION
## Summary
- persist renamed workspaces

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_684c81edec688332a3dc071a6ead4baf