### PR TITLE
Add on_exit handling for workspace saving & hotkey thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ poll-promise = "0.3.0"
 regex = "1.11.1"
 image = "0.25.5"
 
+[features]
+# Enable `glow` support in sync with `eframe` so trait implementations like
+# `on_exit` match the chosen rendering backend.
+glow = ["eframe/glow"]
+
 [profile.release]
 opt-level = 0
 debug = true

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -178,6 +178,26 @@ impl EframeApp for App {
             self.render_settings_window(ctx);
         }
     }
+
+    #[cfg(feature = "glow")]
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        if self.save_on_exit {
+            self.save_workspaces();
+        }
+        if let Some(promise) = self.hotkey_promise.lock().unwrap().take() {
+            promise.cancel();
+        }
+    }
+
+    #[cfg(not(feature = "glow"))]
+    fn on_exit(&mut self) {
+        if self.save_on_exit {
+            self.save_workspaces();
+        }
+        if let Some(promise) = self.hotkey_promise.lock().unwrap().take() {
+            promise.cancel();
+        }
+    }
 }
 
 impl App {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -199,18 +199,8 @@ impl EframeApp for App {
         }
     }
 
-    #[cfg(feature = "glow")]
+    #[cfg_attr(not(feature = "glow"), allow(unused_variables))]
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
-        if self.save_on_exit {
-            self.save_workspaces();
-        }
-        if let Some(promise) = self.hotkey_promise.lock().unwrap().take() {
-            promise.cancel();
-        }
-    }
-
-    #[cfg(not(feature = "glow"))]
-    fn on_exit(&mut self) {
         if self.save_on_exit {
             self.save_workspaces();
         }


### PR DESCRIPTION
## Summary
- implement `on_exit` for `App` with and without `glow`
- save workspaces if `save_on_exit` is true
- cancel the background hotkey thread on exit

## Testing
- `cargo check` *(fails: could not compile due to Win32 crates on this platform)*
- `cargo fmt --all` *(fails: component `rustfmt` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685559a771408332b00cc910a2ed9089