### PR TITLE
Add glow default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ poll-promise = "0.3.0"
 regex = "1.11.1"
 image = "0.25.5"
 
+[features]
+default = ["eframe/glow"]
+
 [profile.release]
 opt-level = 0
 debug = true

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ https://github.com/user-attachments/assets/452cc353-c795-428a-a3e7-dca2cd9c3ce0
    cd multi-manager
    ```
 
-2. Install dependencies:
+2. Build the project (default features include `glow`):
    ```bash
    cargo build
    ```


### PR DESCRIPTION
## Summary
- enable `glow` backend via default Cargo features
- update README build instructions to reflect new default feature

## Testing
- `cargo check` *(fails: could not compile `multi-manager`)*
 