### PR TITLE
Hook Settings menu toggle

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -261,9 +261,6 @@ impl App {
             if ui.button("Send All Home").clicked() {
                 self.send_all_home();
             }
-            if ui.button("Settings").clicked() {
-                self.show_settings = true;
-            }
             let label = if self.all_expanded {
                 "Collapse All"
             } else {


### PR DESCRIPTION
## Summary
- toggle settings dialog from File menu
- remove standalone Settings button from header

## Testing
- `cargo test --quiet` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_6855830bffb0833298128334dedc62b2