### PR TITLE
Add persistent settings with save-on-exit option

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,6 +1,7 @@
 use crate::utils::*;
 use crate::window_manager::{check_hotkeys, send_all_windows_home};
 use crate::workspace::*;
+use crate::settings::{save_settings, Settings};
 use eframe::egui::{self, TopBottomPanel, menu};
 use eframe::egui::collapsing_header::CollapsingState;
 use eframe::egui::ViewportBuilder;
@@ -179,6 +180,15 @@ impl EframeApp for App {
         if self.show_settings {
             self.render_settings_window(ctx);
         }
+    }
+
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        if self.save_on_exit {
+            self.save_workspaces();
+        }
+        save_settings(&Settings {
+            save_on_exit: self.save_on_exit,
+        });
     }
 }
 
@@ -601,7 +611,12 @@ impl App {
             .pivot(egui::Align2::CENTER_CENTER)
             .default_pos(center)
             .show(ctx, |ui| {
-                ui.checkbox(&mut self.save_on_exit, "Save on exit");
+                let response = ui.checkbox(&mut self.save_on_exit, "Save on exit");
+                if response.changed() {
+                    save_settings(&Settings {
+                        save_on_exit: self.save_on_exit,
+                    });
+                }
                 if ui.button("Close").clicked() {
                     self.show_settings = false;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,10 @@ mod hotkey;
 mod utils;
 mod window_manager;
 mod workspace;
+mod settings;
 
 use log::info;
+use crate::settings::load_settings;
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -47,6 +49,8 @@ fn main() {
 
     info!("Starting Multi Manager application...");
 
+    let settings = load_settings();
+
     // Initialize the application states
     let app = gui::App {
         app_title_name: "Multi Manager".to_string(),
@@ -59,7 +63,7 @@ fn main() {
         all_expanded: true,
         expand_all_signal: None,
         show_settings: false,
-        save_on_exit: false,
+        save_on_exit: settings.save_on_exit,
     };
 
     // Launch GUI and set the taskbar icon after creating the window

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{Read, Write};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Settings {
+    pub save_on_exit: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self { save_on_exit: false }
+    }
+}
+
+pub fn load_settings() -> Settings {
+    let mut content = String::new();
+    if let Ok(mut file) = File::open("settings.json") {
+        if file.read_to_string(&mut content).is_ok() {
+            if let Ok(settings) = serde_json::from_str::<Settings>(&content) {
+                return settings;
+            }
+        }
+    }
+    Settings::default()
+}
+
+pub fn save_settings(settings: &Settings) {
+    if let Ok(json) = serde_json::to_string_pretty(settings) {
+        if let Err(e) = File::create("settings.json")
+            .and_then(|mut file| file.write_all(json.as_bytes()))
+        {
+            eprintln!("Failed to save settings: {}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn cleanup() {
+        if Path::new("settings.json").exists() {
+            let _ = fs::remove_file("settings.json");
+        }
+    }
+
+    #[test]
+    fn round_trip_true() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        cleanup();
+        let settings = Settings { save_on_exit: true };
+        save_settings(&settings);
+        let loaded = load_settings();
+        cleanup();
+        assert_eq!(loaded.save_on_exit, true);
+    }
+
+    #[test]
+    fn round_trip_false() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        cleanup();
+        let settings = Settings { save_on_exit: false };
+        save_settings(&settings);
+        let loaded = load_settings();
+        cleanup();
+        assert_eq!(loaded.save_on_exit, false);
+    }
+}


### PR DESCRIPTION
## Summary
- implement Settings module for persisting `save_on_exit`
- load settings in `main` and pass value to `App`
- persist checkbox changes and save workspaces on exit
- unit tests for saving and loading settings

## Testing
- `cargo test --quiet` *(fails: could not compile `multi-manager` due to missing Windows APIs)*

------
https://chatgpt.com/codex/tasks/task_e_685589e5b9708332993a158f5cfb3967