### PR TITLE
Fix hotkey unregistration on workspace removal

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -591,12 +591,17 @@ impl App {
     ///
     /// # Notes
     /// - If the `index` is out of bounds, the function will panic as it directly calls `Vec::remove`.
-    /// - This function does not unregister any associated hotkeys or clean up other resources.
+    /// - If the workspace has a registered hotkey, it will be unregistered before removal.
     ///
     /// # Error Conditions
     /// - Panics if the `index` is greater than or equal to the length of the `workspaces` list.
     fn delete_workspace(&self, index: usize) {
         let mut workspaces = self.workspaces.lock().unwrap();
+        if let Some(workspace) = workspaces.get_mut(index) {
+            if let Some(ref hotkey) = workspace.hotkey {
+                hotkey.unregister(self);
+            }
+        }
         workspaces.remove(index);
     }
 


### PR DESCRIPTION
## Summary
- unregister a workspace's hotkey before removing it

## Testing
- `cargo check` *(fails: could not compile `multi-manager` due to missing Windows target)*

------
https://chatgpt.com/codex/tasks/task_e_685597a197a88332a85cfec2dfbd2cc1