### PR TITLE
Add adjustable log level

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -27,6 +27,7 @@ pub struct App {
     pub expand_all_signal: Option<bool>,
     pub show_settings: bool,
     pub save_on_exit: bool,
+    pub log_level: String,
 }
 
 pub struct WorkspaceControlContext<'a> {
@@ -188,6 +189,7 @@ impl EframeApp for App {
         }
         save_settings(&Settings {
             save_on_exit: self.save_on_exit,
+            log_level: self.log_level.clone(),
         });
     }
 }
@@ -620,6 +622,23 @@ impl App {
                 if response.changed() {
                     save_settings(&Settings {
                         save_on_exit: self.save_on_exit,
+                        log_level: self.log_level.clone(),
+                    });
+                }
+                let mut changed = false;
+                egui::ComboBox::from_label("Log Level")
+                    .selected_text(&self.log_level)
+                    .show_ui(ui, |ui| {
+                        for lvl in ["trace", "debug", "info", "warn", "error", "off"] {
+                            if ui.selectable_value(&mut self.log_level, lvl.to_string(), lvl).clicked() {
+                                changed = true;
+                            }
+                        }
+                    });
+                if changed {
+                    save_settings(&Settings {
+                        save_on_exit: self.save_on_exit,
+                        log_level: self.log_level.clone(),
                     });
                 }
                 if ui.button("Close").clicked() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,11 +5,15 @@ use std::io::{Read, Write};
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Settings {
     pub save_on_exit: bool,
+    pub log_level: String,
 }
 
 impl Default for Settings {
     fn default() -> Self {
-        Self { save_on_exit: false }
+        Self {
+            save_on_exit: false,
+            log_level: "info".to_string(),
+        }
     }
 }
 
@@ -55,21 +59,29 @@ mod tests {
     fn round_trip_true() {
         let _guard = TEST_MUTEX.lock().unwrap();
         cleanup();
-        let settings = Settings { save_on_exit: true };
+        let settings = Settings {
+            save_on_exit: true,
+            log_level: "debug".to_string(),
+        };
         save_settings(&settings);
         let loaded = load_settings();
         cleanup();
         assert_eq!(loaded.save_on_exit, true);
+        assert_eq!(loaded.log_level, "debug");
     }
 
     #[test]
     fn round_trip_false() {
         let _guard = TEST_MUTEX.lock().unwrap();
         cleanup();
-        let settings = Settings { save_on_exit: false };
+        let settings = Settings {
+            save_on_exit: false,
+            log_level: "info".to_string(),
+        };
         save_settings(&settings);
         let loaded = load_settings();
         cleanup();
         assert_eq!(loaded.save_on_exit, false);
+        assert_eq!(loaded.log_level, "info");
     }
 }


### PR DESCRIPTION
## Summary
- extend `Settings` with `log_level`
- allow choosing log level in the settings UI
- persist `log_level` to `settings.json`
- initialize log4rs based on stored level

## Testing
- `cargo test` *(fails: could not compile `multi-manager` due to missing Windows toolchain)*
- `cargo check --target x86_64-pc-windows-msvc` *(fails: target component download blocked)*

 