### PR TITLE
Improve docs and reorganize desktop menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ https://github.com/user-attachments/assets/452cc353-c795-428a-a3e7-dca2cd9c3ce0
 - **Persistent Storage**:
   - Save and load workspace configurations in JSON format.
   - Pretty-printed JSON for easy manual editing.
+- **Desktop Management**:
+  - Save and restore window layouts across all virtual desktops from the **File -> Desktop Management** menu.
 - **Visual Feedback**:
   - Color-coded HWND validity indicators for associated windows.
   - Popup dialogs for feedback (e.g., workspace saved successfully).
@@ -120,6 +122,12 @@ https://github.com/user-attachments/assets/452cc353-c795-428a-a3e7-dca2cd9c3ce0
    - Enter a valid hotkey combination in the input field.
    - Click "Validate Hotkey" to confirm.
 2. **Activate Workspace**: Use the assigned hotkey to activate the workspace and toggle window positions.
+
+### Desktop Management
+
+1. Open **File -> Desktop Management**.
+2. Choose **Save All Desktops** to store the current window layout.
+3. Choose **Restore All Desktops** to reload the saved layout.
 
 ---
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -208,6 +208,17 @@ impl App {
         TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             menu::bar(ui, |ui| {
                 ui.menu_button("File", |ui| {
+                    ui.menu_button("Desktop Management", |ui| {
+                        if ui.button("Save All Desktops").clicked() {
+                            capture_all_desktops("desktop_layout.json");
+                            show_message_box("Desktops saved", "Save");
+                            ui.close_menu();
+                        }
+                        if ui.button("Restore All Desktops").clicked() {
+                            restore_all_desktops("desktop_layout.json");
+                            ui.close_menu();
+                        }
+                    });
                     if ui.button("Settings").clicked() {
                         self.show_settings = true;
                         ui.close_menu();
@@ -277,13 +288,6 @@ impl App {
             }
             if ui.button("Send All Home").clicked() {
                 self.send_all_home();
-            }
-            if ui.button("Save All Desktops").clicked() {
-                capture_all_desktops("desktop_layout.json");
-                show_message_box("Desktops saved", "Save");
-            }
-            if ui.button("Restore All Desktops").clicked() {
-                restore_all_desktops("desktop_layout.json");
             }
             let label = if self.all_expanded {
                 "Collapse All"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,15 +2,23 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{Read, Write};
 
+/// Persistent configuration options loaded from and saved to `settings.json`.
+///
+/// These values control global behavior such as logging verbosity and whether
+/// the application should automatically save workspaces on exit.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Settings {
+    /// If `true`, workspaces are automatically saved when the application exits.
     pub save_on_exit: bool,
+    /// The log level used when initializing the logger (e.g. `"info"`).
     pub log_level: String,
+    /// Optional path to the last desktop layout file used.
     #[serde(default)]
     pub last_layout_file: Option<String>,
 }
 
 impl Default for Settings {
+    /// Returns a `Settings` instance with sensible defaults.
     fn default() -> Self {
         Self {
             save_on_exit: false,
@@ -20,6 +28,9 @@ impl Default for Settings {
     }
 }
 
+/// Load persisted settings from `settings.json` if it exists.
+///
+/// If the file cannot be read or parsed, default settings are returned.
 pub fn load_settings() -> Settings {
     let mut content = String::new();
     if let Ok(mut file) = File::open("settings.json") {
@@ -32,6 +43,8 @@ pub fn load_settings() -> Settings {
     Settings::default()
 }
 
+/// Save the provided `settings` struct to `settings.json` in a human
+/// readable format.
 pub fn save_settings(settings: &Settings) {
     if let Ok(json) = serde_json::to_string_pretty(settings) {
         if let Err(e) = File::create("settings.json")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,31 +3,11 @@ use windows::core::PCWSTR;
 use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-/// Determines whether the specified `hwnd` is currently located at the given **(x, y)** coordinates
-/// with the specified **width** and **height**.
+/// Display a simple informational message box with an "OK" button.
 ///
-/// # Behavior
-/// - Retrieves the window’s current position and size using
-///   [`get_window_position`](#fn.get_window_position).
-/// - Compares the returned `(x, y, width, height)` tuple to the provided parameters.
-/// - Returns `true` if they match exactly, otherwise `false`.
-///
-/// # Side Effects
-/// - Calls `get_window_position`, which uses the Win32 API [`GetWindowRect`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowrect)
-///   to retrieve the actual window rectangle on screen.
-///
-/// # Example
-/// ```rust
-/// if is_window_at_position(hwnd, 100, 100, 800, 600) {
-///     println!("The window is exactly at (100, 100) with size (800x600).");
-/// } else {
-///     println!("The window is not at the specified position/size.");
-/// }
-/// ```
-///
-/// # Notes
-/// - If `get_window_position` fails or returns an error, this function returns `false`.
-/// - Primarily used internally (e.g., in `are_all_windows_at_home`).
+/// This is a thin wrapper around the Windows API `MessageBoxW` function.
+/// It is primarily used to provide quick feedback to the user (e.g., when
+/// workspaces or desktop layouts are successfully saved).
 pub fn show_message_box(message: &str, title: &str) {
     unsafe {
         MessageBoxW(

--- a/src/virtual_desktop.rs
+++ b/src/virtual_desktop.rs
@@ -2,6 +2,9 @@
 use windows::Win32::Foundation::HWND;
 #[cfg(target_os = "windows")]
 use windows::core::Result;
+/// Represents a virtual desktop. Only a minimal stub implementation is
+/// provided as full virtual desktop manipulation is outside the scope of this
+/// project.
 #[cfg(target_os = "windows")]
 #[derive(Clone)]
 pub struct Desktop {
@@ -15,21 +18,25 @@ impl Desktop {
     }
 }
 
+/// Retrieve the current active virtual desktop.
 #[cfg(target_os = "windows")]
 pub fn get_current_desktop() -> Result<Desktop> {
     Ok(Desktop { index: 0 })
 }
 
+/// Enumerate available virtual desktops.
 #[cfg(target_os = "windows")]
 pub fn get_desktops() -> Result<Vec<Desktop>> {
     Ok(vec![Desktop { index: 0 }])
 }
 
+/// Switch to the provided desktop.
 #[cfg(target_os = "windows")]
 pub fn switch_desktop(_desktop: &Desktop) -> Result<()> {
     Ok(())
 }
 
+/// Obtain the desktop that owns the specified window handle.
 #[cfg(target_os = "windows")]
 pub fn get_desktop_by_window(_hwnd: HWND) -> Result<Desktop> {
     Ok(Desktop { index: 0 })
@@ -41,12 +48,14 @@ use windows::Win32::Foundation::HWND;
 pub type Result<T> = std::result::Result<T, String>;
 #[cfg(not(target_os = "windows"))]
 #[derive(Clone)]
+/// Minimal stand-in struct for non-Windows builds.
 pub struct Desktop {
     index: u32,
 }
 
 #[cfg(not(target_os = "windows"))]
 impl Desktop {
+    /// Return the index of this desktop.
     pub fn get_index(&self) -> Result<u32> {
         Ok(self.index)
     }


### PR DESCRIPTION
## Summary
- document Settings struct and helpers
- add menu for Desktop Management
- clean up message box docs and default virtual desktop stubs
- document missing functionality in the README

## Testing
- `cargo test` *(fails: could not find `Win32` in `windows`)*

 