### PR TITLE
Use workspace name in delete confirmation

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -499,7 +499,7 @@ impl App {
             if ui.button("Delete Workspace").clicked() {
                 let confirmation_message = format!(
                     "Are you sure you want to delete workspace '{}'? This action cannot be undone.",
-                    context.index
+                    &workspace.name
                 );
                 if show_confirmation_box(&confirmation_message, "Confirm Deletion") {
                     *context.workspace_to_delete = Some(context.index);


### PR DESCRIPTION
## Summary
- show workspace name in delete confirmation instead of index

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*

 