### PR TITLE
Fix GetWindowRect boolean check

### DIFF
--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -425,7 +425,7 @@ fn is_window_at_position(hwnd: HWND, x: i32, y: i32, w: i32, h: i32) -> bool {
 pub fn get_window_position(hwnd: HWND) -> Result<(i32, i32, i32, i32)> {
     unsafe {
         let mut rect = RECT::default();
-        if GetWindowRect(hwnd, &mut rect).is_ok() {
+        if GetWindowRect(hwnd, &mut rect).as_bool() {
             Ok((
                 rect.left,
                 rect.top,


### PR DESCRIPTION
## Summary
- fix boolean check for GetWindowRect return value

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*

 