### PR TITLE
Add layout file persistence with file dialogs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ log4rs = "1.3"
 poll-promise = "0.3.0"
 regex = "1.11.1"
 image = "0.25.5"
+rfd = "0.15"
 
 [profile.release]
 opt-level = 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ fn main() {
         show_settings: false,
         save_on_exit: settings.save_on_exit,
         log_level: settings.log_level.clone(),
+        last_layout_file: settings.last_layout_file.clone(),
     };
 
     // Launch GUI and set the taskbar icon after creating the window


### PR DESCRIPTION
## Summary
- remember last desktop layout file in `App`
- save last layout file path into `settings.json`
- use `rfd` dialogs to choose layout file when saving/restoring desktops
- allow editing the layout file path in the Settings window
- add `rfd` crate dependency

## Testing
- `cargo test` *(fails: could not compile `multi-manager` due to missing Windows APIs)*

 