### PR TITLE
Add CLI arguments for desktop layout management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ poll-promise = "0.3.0"
 regex = "1.11.1"
 image = "0.25.5"
 rfd = "0.15"
+clap = { version = "4", features = ["derive"] }
 
 [profile.release]
 opt-level = 0

--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ https://github.com/user-attachments/assets/452cc353-c795-428a-a3e7-dca2cd9c3ce0
 2. Choose **Save All Desktops** to store the current window layout.
 3. Choose **Restore All Desktops** to reload the saved layout.
 
+### Command Line Examples
+
+Run the application with optional arguments to save or load all desktop layouts:
+
+```bash
+cargo run -- --save-desktops
+cargo run -- --save-desktops custom.json
+cargo run -- --load-desktops
+cargo run -- --load-desktops custom.json
+```
+
 ---
 
 ## Configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,21 @@ mod virtual_desktop;
 mod desktop_window_info;
 
 use log::info;
+use clap::Parser;
 use crate::settings::load_settings;
+use crate::window_manager::{capture_all_desktops, restore_all_desktops};
 use std::collections::HashMap;
 use std::env;
 use std::sync::{Arc, Mutex};
+
+#[derive(Parser, Debug)]
+struct CliArgs {
+    #[arg(long = "save-desktops", default_missing_value = "desktop_layout.json", num_args = 0..=1)]
+    save_desktops: Option<String>,
+
+    #[arg(long = "load-desktops", default_missing_value = "desktop_layout.json", num_args = 0..=1)]
+    load_desktops: Option<String>,
+}
 
 /// The main entry point for the Multi Manager application.
 ///
@@ -41,6 +52,8 @@ use std::sync::{Arc, Mutex};
 /// }
 /// ```
 fn main() {
+    let args = CliArgs::parse();
+
     // Ensure logging is initialized
     ensure_logging_initialized();
 
@@ -48,6 +61,16 @@ fn main() {
     env::set_var("RUST_BACKTRACE", "1");
 
     info!("Starting Multi Manager application...");
+
+    if let Some(file) = args.save_desktops {
+        capture_all_desktops(&file);
+        return;
+    }
+
+    if let Some(file) = args.load_desktops {
+        restore_all_desktops(&file);
+        return;
+    }
 
     let settings = load_settings();
 


### PR DESCRIPTION
## Summary
- add clap dependency
- parse command line arguments in `main.rs`
- expose commands to save/load desktop layouts
- document example commands in README

## Testing
- `cargo check` *(fails: could not compile `multi-manager` due to missing Win32 APIs)*

------
https://chatgpt.com/codex/tasks/task_e_685b3719f67c8332b7590139ae44dd15