### PR TITLE
Conditional console allocation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,14 @@ struct CliArgs {
 /// }
 /// ```
 fn main() {
-    ensure_console();
+    // Count the number of command line arguments. If there is only one
+    // (the program name) we skip attaching/allocating a console so that
+    // help messages still show correctly when invoked without extra
+    // parameters.
+    let arg_count = std::env::args_os().len();
+    if arg_count > 1 {
+        ensure_console();
+    }
     let args = CliArgs::parse();
 
     // Ensure logging is initialized


### PR DESCRIPTION
## Summary
- only attach/allocate a console when arguments are passed

## Testing
- `cargo check` *(fails: `x86_64-pc-windows-gnu` target not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b4519c6f08332976e5350ca60a318