### PR TITLE
Disable hotkey validation when workspace disabled

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -808,6 +808,9 @@ impl App {
         if !*initial_validation_done {
             let mut workspaces = self.workspaces.lock().unwrap();
             for (i, workspace) in workspaces.iter_mut().enumerate() {
+                if workspace.disabled {
+                    continue;
+                }
                 if let Some(ref mut hotkey) = workspace.hotkey {
                     if !hotkey.register(self, i as i32) {
                         warn!(


### PR DESCRIPTION
## Summary
- skip registering hotkeys for disabled workspaces
- avoid validating hotkeys when a workspace is disabled

## Testing
- `cargo check` *(fails: could not compile due to missing Windows dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c7025f6608332be6fde8ba5cbb321