### PR TITLE
Add hotkey capture dialog

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ fn main() {
         initial_validation_done: Arc::new(Mutex::new(false)), // Initialize flag to false
         registered_hotkeys: Arc::new(Mutex::new(HashMap::new())), // Initialize the map
         rename_dialog: None,
+        hotkey_dialog: None,
         all_expanded: true,
         expand_all_signal: None,
         show_settings: false,


### PR DESCRIPTION
## Summary
- introduce `hotkey_dialog` app state and use it when editing hotkeys
- capture hotkey combinations in a modal egui dialog
- replace manual text entry for workspace hotkeys

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*
 