### PR TITLE
Register hotkeys when changed

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -582,7 +582,7 @@ impl App {
             if confirm {
                 let mut workspaces = self.workspaces.lock().unwrap();
                 if let Some(ws) = workspaces.get_mut(index) {
-                    let _ = ws.set_hotkey(&sequence);
+                    let _ = ws.set_hotkey(self, &sequence);
                     self.unsaved_changes = true;
                 }
             } else if !close_dialog {


### PR DESCRIPTION
## Summary
- change `Workspace::set_hotkey` to take `app: &App`
- unregister old hotkeys and register new ones immediately
- update caller in GUI

## Testing
- `cargo check` *(fails: could not compile `multi-manager`)*
 