### PR TITLE
Add log folder menu

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -295,6 +295,10 @@ impl App {
                             ui.close_menu();
                         }
                     });
+                    if ui.button("Open Log Folder").clicked() {
+                        self.open_log_folder();
+                        ui.close_menu();
+                    }
                     if ui.button("Settings").clicked() {
                         self.show_settings = true;
                         ui.close_menu();
@@ -854,6 +858,19 @@ impl App {
     fn send_all_home(&self) {
         let mut workspaces = self.workspaces.lock().unwrap();
         send_all_windows_home(&mut workspaces);
+    }
+
+    /// Open the folder containing `multi_manager.log` using Windows Explorer.
+    fn open_log_folder(&self) {
+        use std::path::PathBuf;
+        use std::process::Command;
+
+        let log_path = std::fs::canonicalize("multi_manager.log")
+            .unwrap_or_else(|_| PathBuf::from("multi_manager.log"));
+
+        if let Err(e) = Command::new("explorer").arg(&log_path).spawn() {
+            show_error_box(&format!("Failed to open log folder: {}", e), "Error");
+        }
     }
 
     /// Validates and registers hotkeys for all workspaces during initialization.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -83,3 +83,29 @@ pub fn show_confirmation_box(message: &str, title: &str) -> bool {
         result == windows::Win32::UI::WindowsAndMessaging::MESSAGEBOX_RESULT(6) // IDYES is defined as 6
     }
 }
+
+/// Display an error message box with an "OK" button.
+///
+/// This is similar to [`show_message_box`] but uses a red error icon.
+pub fn show_error_box(message: &str, title: &str) {
+    unsafe {
+        MessageBoxW(
+            HWND(ptr::null_mut()),
+            PCWSTR(
+                message
+                    .encode_utf16()
+                    .chain(Some(0))
+                    .collect::<Vec<u16>>()
+                    .as_ptr(),
+            ),
+            PCWSTR(
+                title
+                    .encode_utf16()
+                    .chain(Some(0))
+                    .collect::<Vec<u16>>()
+                    .as_ptr(),
+            ),
+            MB_OK | MB_ICONERROR,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add error dialog helper
- add menu option to open log folder
- spawn `explorer` on click and show error on failure

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_685c9e59f27083329fc1db97b276e8b8