### PR TITLE
Handle hotkey registration failure

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -586,8 +586,10 @@ impl App {
             if confirm {
                 let mut workspaces = self.workspaces.lock().unwrap();
                 if let Some(ws) = workspaces.get_mut(index) {
-                    let _ = ws.set_hotkey(self, &sequence);
-                    self.unsaved_changes = true;
+                    match ws.set_hotkey(self, &sequence) {
+                        Ok(()) => self.unsaved_changes = true,
+                        Err(e) => show_error_box(&e, "Hotkey Error"),
+                    }
                 }
             } else if !close_dialog {
                 self.hotkey_dialog = Some((index, sequence));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -43,7 +43,7 @@ impl Workspace {
     ///
     /// # Returns
     /// - `Ok(())` if the hotkey is valid and successfully set.
-    /// - `Err` with an error message if the hotkey is invalid.
+    /// - `Err` with an error message if the hotkey is invalid or fails to register.
     ///
     /// # Example
     /// ```
@@ -66,10 +66,12 @@ impl Workspace {
                 };
 
                 // Try to register immediately so the map stays accurate
-                new_hotkey.register(app, id);
-
-                self.hotkey = Some(new_hotkey);
-                Ok(())
+                if new_hotkey.register(app, id) {
+                    self.hotkey = Some(new_hotkey);
+                    Ok(())
+                } else {
+                    Err(format!("Failed to register hotkey: {}", hotkey))
+                }
             }
             Err(e) => Err(e),
         }


### PR DESCRIPTION
## Summary
- return an error from `Workspace::set_hotkey` when registration fails
- show an error dialog in the GUI if setting the hotkey fails

## Testing
- `cargo check` *(fails: could not compile due to missing Windows-specific dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dc40696348332a66fc4020675683c