### PR TITLE
Add window thumbnail feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ windows = { version = "0.58", features = [
     "Win32_UI_Shell_Common",
     "Win32_System_Threading",
     "Win32_System_Console",
+    "Win32_Graphics_Gdi",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- show thumbnails for windows in `render_details`
- store cached thumbnails per window
- capture window images using `PrintWindow` or `BitBlt`
- include new Windows GDI feature

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_685dd88e6da48332b2d888b6809f0836