### PR TITLE
Use static regex in is_valid_key_combo

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -6,12 +6,17 @@ use crate::window_manager::move_window;
 use crate::window_manager::*;
 use eframe::egui;
 use log::{error, info, warn};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{Read, Write};
 use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::WindowsAndMessaging::IsWindow;
+
+static HOTKEY_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:F(?:[1-9]|1[0-2]|1[3-9]|2[0-4])|[A-Z]|[0-9]|NUMPAD[0-9]|NUMPAD(?:MULTIPLY|ADD|SEPARATOR|SUBTRACT|DOT|DIVIDE)|UP|DOWN|LEFT|RIGHT|BACKSPACE|TAB|ENTER|PAUSE|CAPSLOCK|ESCAPE|SPACE|PAGEUP|PAGEDOWN|END|HOME|INSERT|DELETE|OEM_(?:PLUS|COMMA|MINUS|PERIOD|[1-7])|PRINTSCREEN|SCROLLLOCK|NUMLOCK|LEFT(?:SHIFT|CTRL|ALT)|RIGHT(?:SHIFT|CTRL|ALT))$").unwrap()
+});
 
 /// Represents a workspace, which groups multiple windows and allows toggling between specific positions.
 ///
@@ -593,9 +598,7 @@ pub struct Window {
 /// - This function does not verify whether the key is actually usable in Windows (for that, see
 ///   [`virtual_key_from_string`](../../window_manager/fn.virtual_key_from_string.html)).
 pub fn is_valid_key_combo(input: &str) -> bool {
-    let pattern = r"^(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:F(?:[1-9]|1[0-2]|1[3-9]|2[0-4])|[A-Z]|[0-9]|NUMPAD[0-9]|NUMPAD(?:MULTIPLY|ADD|SEPARATOR|SUBTRACT|DOT|DIVIDE)|UP|DOWN|LEFT|RIGHT|BACKSPACE|TAB|ENTER|PAUSE|CAPSLOCK|ESCAPE|SPACE|PAGEUP|PAGEDOWN|END|HOME|INSERT|DELETE|OEM_(?:PLUS|COMMA|MINUS|PERIOD|[1-7])|PRINTSCREEN|SCROLLLOCK|NUMLOCK|LEFT(?:SHIFT|CTRL|ALT)|RIGHT(?:SHIFT|CTRL|ALT))$";
-    let re = Regex::new(pattern).unwrap();
-    re.is_match(input)
+    HOTKEY_REGEX.is_match(input)
 }
 
 /// Saves a list of workspaces to a JSON file.


### PR DESCRIPTION
## Summary
- create a static regex with `once_cell::sync::Lazy`
- use the static regex for hotkey validation

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*
 