### PR TITLE
Add theme customization to settings

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -7,7 +7,7 @@ use crate::window_manager::{
     move_all_to_origin,
 };
 use crate::workspace::*;
-use crate::settings::{save_settings, Settings};
+use crate::settings::{save_settings, Settings, ThemeMode};
 use eframe::egui::{self, TopBottomPanel, menu};
 use eframe::egui::ViewportBuilder;
 use eframe::NativeOptions;
@@ -39,6 +39,9 @@ pub struct App {
     pub log_level: String,
     pub last_layout_file: Option<String>,
     pub last_workspace_file: Option<String>,
+    pub theme: ThemeMode,
+    pub custom_bg: Option<[u8; 4]>,
+    pub custom_accent: Option<[u8; 4]>,
 }
 
 pub struct WorkspaceControlContext<'a> {
@@ -212,6 +215,9 @@ impl EframeApp for App {
             log_level: self.log_level.clone(),
             last_layout_file: self.last_layout_file.clone(),
             last_workspace_file: self.last_workspace_file.clone(),
+            theme: self.theme,
+            custom_bg: self.custom_bg,
+            custom_accent: self.custom_accent,
         });
     }
 }
@@ -244,6 +250,9 @@ impl App {
                                 log_level: self.log_level.clone(),
                                 last_layout_file: self.last_layout_file.clone(),
                                 last_workspace_file: self.last_workspace_file.clone(),
+                                theme: self.theme,
+                                custom_bg: self.custom_bg,
+                                custom_accent: self.custom_accent,
                             });
                             show_message_box("Desktops saved", "Save");
                             ui.close_menu();
@@ -266,6 +275,9 @@ impl App {
                                 log_level: self.log_level.clone(),
                                 last_layout_file: self.last_layout_file.clone(),
                                 last_workspace_file: self.last_workspace_file.clone(),
+                                theme: self.theme,
+                                custom_bg: self.custom_bg,
+                                custom_accent: self.custom_accent,
                             });
                             ui.close_menu();
                         }
@@ -737,6 +749,9 @@ impl App {
             log_level: self.log_level.clone(),
             last_layout_file: self.last_layout_file.clone(),
             last_workspace_file: self.last_workspace_file.clone(),
+            theme: self.theme,
+            custom_bg: self.custom_bg,
+            custom_accent: self.custom_accent,
         });
     }
 
@@ -833,6 +848,9 @@ impl App {
                         log_level: self.log_level.clone(),
                         last_layout_file: None,
                         last_workspace_file: self.last_workspace_file.clone(),
+                        theme: self.theme,
+                        custom_bg: self.custom_bg,
+                        custom_accent: self.custom_accent,
                     });
                 }
                 let auto_response = ui.checkbox(&mut self.auto_save, "Auto-save");
@@ -843,6 +861,9 @@ impl App {
                         log_level: self.log_level.clone(),
                         last_layout_file: self.last_layout_file.clone(),
                         last_workspace_file: self.last_workspace_file.clone(),
+                        theme: self.theme,
+                        custom_bg: self.custom_bg,
+                        custom_accent: self.custom_accent,
                     });
                 }
                 let mut changed = false;
@@ -862,6 +883,9 @@ impl App {
                         log_level: self.log_level.clone(),
                         last_layout_file: self.last_layout_file.clone(),
                         last_workspace_file: self.last_workspace_file.clone(),
+                        theme: self.theme,
+                        custom_bg: self.custom_bg,
+                        custom_accent: self.custom_accent,
                     });
                 }
                 let mut path = self.last_layout_file.clone().unwrap_or_default();
@@ -879,6 +903,9 @@ impl App {
                             log_level: self.log_level.clone(),
                             last_layout_file: self.last_layout_file.clone(),
                             last_workspace_file: self.last_workspace_file.clone(),
+                            theme: self.theme,
+                            custom_bg: self.custom_bg,
+                            custom_accent: self.custom_accent,
                         });
                     }
                 });
@@ -991,6 +1018,9 @@ impl App {
             log_level: self.log_level.clone(),
             last_layout_file: self.last_layout_file.clone(),
             last_workspace_file: self.last_workspace_file.clone(),
+            theme: self.theme,
+            custom_bg: self.custom_bg,
+            custom_accent: self.custom_accent,
         });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,9 @@ fn main() {
         log_level: settings.log_level.clone(),
         last_layout_file: settings.last_layout_file.clone(),
         last_workspace_file: settings.last_workspace_file.clone(),
+        theme: settings.theme,
+        custom_bg: settings.custom_bg,
+        custom_accent: settings.custom_accent,
     };
 
     // Launch GUI and set the taskbar icon after creating the window

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,20 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{Read, Write};
 
+/// Theme mode for the application's appearance.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemeMode {
+    Dark,
+    Light,
+    Custom,
+}
+
+impl Default for ThemeMode {
+    fn default() -> Self {
+        ThemeMode::Dark
+    }
+}
+
 /// Persistent configuration options loaded from and saved to `settings.json`.
 ///
 /// These values control global behavior such as logging verbosity and whether
@@ -21,6 +35,15 @@ pub struct Settings {
     /// Optional path to the last workspace file used.
     #[serde(default)]
     pub last_workspace_file: Option<String>,
+    /// Theme mode for the GUI.
+    #[serde(default)]
+    pub theme: ThemeMode,
+    /// Custom background color in RGBA when `theme` is `Custom`.
+    #[serde(default)]
+    pub custom_bg: Option<[u8; 4]>,
+    /// Custom accent color in RGBA when `theme` is `Custom`.
+    #[serde(default)]
+    pub custom_accent: Option<[u8; 4]>,
 }
 
 impl Default for Settings {
@@ -32,6 +55,9 @@ impl Default for Settings {
             log_level: "info".to_string(),
             last_layout_file: None,
             last_workspace_file: None,
+            theme: ThemeMode::Dark,
+            custom_bg: None,
+            custom_accent: None,
         }
     }
 }
@@ -89,6 +115,9 @@ mod tests {
             log_level: "debug".to_string(),
             last_layout_file: Some("file.json".into()),
             last_workspace_file: Some("work.json".into()),
+            theme: ThemeMode::Custom,
+            custom_bg: Some([1, 2, 3, 4]),
+            custom_accent: Some([5, 6, 7, 8]),
         };
         save_settings(&settings);
         let loaded = load_settings();
@@ -98,6 +127,9 @@ mod tests {
         assert_eq!(loaded.log_level, "debug");
         assert_eq!(loaded.last_layout_file.as_deref(), Some("file.json"));
         assert_eq!(loaded.last_workspace_file.as_deref(), Some("work.json"));
+        assert_eq!(loaded.theme, ThemeMode::Custom);
+        assert_eq!(loaded.custom_bg, Some([1, 2, 3, 4]));
+        assert_eq!(loaded.custom_accent, Some([5, 6, 7, 8]));
     }
 
     #[test]
@@ -110,6 +142,9 @@ mod tests {
             log_level: "info".to_string(),
             last_layout_file: None,
             last_workspace_file: None,
+            theme: ThemeMode::Dark,
+            custom_bg: None,
+            custom_accent: None,
         };
         save_settings(&settings);
         let loaded = load_settings();
@@ -119,5 +154,8 @@ mod tests {
         assert_eq!(loaded.log_level, "info");
         assert_eq!(loaded.last_layout_file, None);
         assert_eq!(loaded.last_workspace_file, None);
+        assert_eq!(loaded.theme, ThemeMode::Dark);
+        assert_eq!(loaded.custom_bg, None);
+        assert_eq!(loaded.custom_accent, None);
     }
 }


### PR DESCRIPTION
## Summary
- add `ThemeMode` enum for light/dark/custom themes
- extend `Settings` with theme fields and optional custom colors
- update defaults, load/save helpers, and unit tests
- store theme info in `App` and propagate when saving settings

## Testing
- `cargo test --quiet` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_6860128fc8f48332b056ed68d207673d