### PR TITLE
Handle minimized window restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ https://github.com/user-attachments/assets/452cc353-c795-428a-a3e7-dca2cd9c3ce0
 1. **Assign Hotkeys**:
    - Enter a valid hotkey combination in the input field.
    - Click "Validate Hotkey" to confirm.
-2. **Activate Workspace**: Use the assigned hotkey to activate the workspace and toggle window positions.
+2. **Activate Workspace**: Use the assigned hotkey to activate the workspace and toggle window positions. Minimized windows are restored at their saved coordinates.
 
 ### Desktop Management
 


### PR DESCRIPTION
## Summary
- add `set_restore_position` helper
- restore minimized windows inside `move_window`
- stop manual ShowWindow calls in toggle and restore helpers
- mention restored minimized windows in README usage

## Testing
- `cargo check` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_6861759821b08332a238896909d1645d