### PR TITLE
Add developer debugging setting

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -39,6 +39,7 @@ pub struct App {
     pub log_level: String,
     pub last_layout_file: Option<String>,
     pub last_workspace_file: Option<String>,
+    pub developer_debugging: bool,
 }
 
 pub struct WorkspaceControlContext<'a> {
@@ -212,6 +213,7 @@ impl EframeApp for App {
             log_level: self.log_level.clone(),
             last_layout_file: self.last_layout_file.clone(),
             last_workspace_file: self.last_workspace_file.clone(),
+            developer_debugging: self.developer_debugging,
         });
     }
 }
@@ -244,6 +246,7 @@ impl App {
                                 log_level: self.log_level.clone(),
                                 last_layout_file: self.last_layout_file.clone(),
                                 last_workspace_file: self.last_workspace_file.clone(),
+                                developer_debugging: self.developer_debugging,
                             });
                             show_message_box("Desktops saved", "Save");
                             ui.close_menu();
@@ -266,6 +269,7 @@ impl App {
                                 log_level: self.log_level.clone(),
                                 last_layout_file: self.last_layout_file.clone(),
                                 last_workspace_file: self.last_workspace_file.clone(),
+                                developer_debugging: self.developer_debugging,
                             });
                             ui.close_menu();
                         }
@@ -737,6 +741,7 @@ impl App {
             log_level: self.log_level.clone(),
             last_layout_file: self.last_layout_file.clone(),
             last_workspace_file: self.last_workspace_file.clone(),
+            developer_debugging: self.developer_debugging,
         });
     }
 
@@ -833,6 +838,7 @@ impl App {
                         log_level: self.log_level.clone(),
                         last_layout_file: None,
                         last_workspace_file: self.last_workspace_file.clone(),
+                        developer_debugging: self.developer_debugging,
                     });
                 }
                 let auto_response = ui.checkbox(&mut self.auto_save, "Auto-save");
@@ -843,6 +849,18 @@ impl App {
                         log_level: self.log_level.clone(),
                         last_layout_file: self.last_layout_file.clone(),
                         last_workspace_file: self.last_workspace_file.clone(),
+                        developer_debugging: self.developer_debugging,
+                    });
+                }
+                let dev_response = ui.checkbox(&mut self.developer_debugging, "Developer Debugging");
+                if dev_response.changed() {
+                    save_settings(&Settings {
+                        save_on_exit: self.save_on_exit,
+                        auto_save: self.auto_save,
+                        log_level: self.log_level.clone(),
+                        last_layout_file: self.last_layout_file.clone(),
+                        last_workspace_file: self.last_workspace_file.clone(),
+                        developer_debugging: self.developer_debugging,
                     });
                 }
                 let mut changed = false;
@@ -862,6 +880,7 @@ impl App {
                         log_level: self.log_level.clone(),
                         last_layout_file: self.last_layout_file.clone(),
                         last_workspace_file: self.last_workspace_file.clone(),
+                        developer_debugging: self.developer_debugging,
                     });
                 }
                 let mut path = self.last_layout_file.clone().unwrap_or_default();
@@ -879,6 +898,7 @@ impl App {
                             log_level: self.log_level.clone(),
                             last_layout_file: self.last_layout_file.clone(),
                             last_workspace_file: self.last_workspace_file.clone(),
+                            developer_debugging: self.developer_debugging,
                         });
                     }
                 });
@@ -991,6 +1011,7 @@ impl App {
             log_level: self.log_level.clone(),
             last_layout_file: self.last_layout_file.clone(),
             last_workspace_file: self.last_workspace_file.clone(),
+            developer_debugging: self.developer_debugging,
         });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ fn main() {
         log_level: settings.log_level.clone(),
         last_layout_file: settings.last_layout_file.clone(),
         last_workspace_file: settings.last_workspace_file.clone(),
+        developer_debugging: settings.developer_debugging,
     };
 
     // Launch GUI and set the taskbar icon after creating the window

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,9 @@ pub struct Settings {
     /// Optional path to the last workspace file used.
     #[serde(default)]
     pub last_workspace_file: Option<String>,
+    /// If `true`, additional developer debugging information is shown.
+    #[serde(default)]
+    pub developer_debugging: bool,
 }
 
 impl Default for Settings {
@@ -32,6 +35,7 @@ impl Default for Settings {
             log_level: "info".to_string(),
             last_layout_file: None,
             last_workspace_file: None,
+            developer_debugging: false,
         }
     }
 }
@@ -89,6 +93,7 @@ mod tests {
             log_level: "debug".to_string(),
             last_layout_file: Some("file.json".into()),
             last_workspace_file: Some("work.json".into()),
+            developer_debugging: true,
         };
         save_settings(&settings);
         let loaded = load_settings();
@@ -98,6 +103,7 @@ mod tests {
         assert_eq!(loaded.log_level, "debug");
         assert_eq!(loaded.last_layout_file.as_deref(), Some("file.json"));
         assert_eq!(loaded.last_workspace_file.as_deref(), Some("work.json"));
+        assert_eq!(loaded.developer_debugging, true);
     }
 
     #[test]
@@ -110,6 +116,7 @@ mod tests {
             log_level: "info".to_string(),
             last_layout_file: None,
             last_workspace_file: None,
+            developer_debugging: false,
         };
         save_settings(&settings);
         let loaded = load_settings();
@@ -119,5 +126,6 @@ mod tests {
         assert_eq!(loaded.log_level, "info");
         assert_eq!(loaded.last_layout_file, None);
         assert_eq!(loaded.last_workspace_file, None);
+        assert_eq!(loaded.developer_debugging, false);
     }
 }

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -486,7 +486,7 @@ pub fn restore_all_desktops(_file: &str) {
 /// # Notes
 /// - If `get_window_position` fails or returns an error, this function returns `false`.
 /// - Primarily used internally (e.g., in `are_all_windows_at_home`).
-fn is_window_at_position(hwnd: HWND, x: i32, y: i32, w: i32, h: i32) -> bool {
+pub fn is_window_at_position(hwnd: HWND, x: i32, y: i32, w: i32, h: i32) -> bool {
     if let Ok((wx, wy, ww, wh)) = get_window_position(hwnd) {
         wx == x && wy == y && ww == w && wh == h
     } else {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4,6 +4,7 @@ use crate::window_manager::get_window_position;
 use crate::window_manager::listen_for_keys_with_dialog_and_window;
 use crate::window_manager::move_window;
 use crate::window_manager::move_window_to_origin;
+use crate::window_manager::is_window_at_position;
 use crate::window_manager::*;
 use eframe::egui;
 use log::{error, info, warn};
@@ -234,10 +235,23 @@ impl Workspace {
                 let exists =
                     unsafe { IsWindow(HWND(window.id as *mut std::ffi::c_void)).as_bool() };
                 if exists {
+                    // Determine current location if debugging is enabled
+                    let debug_info = if app.developer_debugging {
+                        let hwnd = HWND(window.id as *mut std::ffi::c_void);
+                        if is_window_at_position(hwnd, window.home.0, window.home.1, window.home.2, window.home.3) {
+                            " home"
+                        } else if is_window_at_position(hwnd, window.target.0, window.target.1, window.target.2, window.target.3) {
+                            " target"
+                        } else {
+                            " neither"
+                        }
+                    } else {
+                        ""
+                    };
                     // Define the label and capture its response
                     let label_response = ui.colored_label(
                         egui::Color32::GREEN,
-                        format!("HWND: {:?}", window.id),
+                        format!("HWND: {:?}{}", window.id, debug_info),
                     );
                 
                     // Create a unique ID for the popup menu


### PR DESCRIPTION
## Summary
- allow enabling developer debugging in settings
- persist developer debugging setting
- show window location when debugging is enabled
- expose `is_window_at_position` for other modules

## Testing
- `cargo test` *(fails: could not compile `multi-manager` due to missing Windows APIs)*

 