### PR TITLE
Add Recapture All option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ fn main() {
         last_layout_file: settings.last_layout_file.clone(),
         last_workspace_file: settings.last_workspace_file.clone(),
         developer_debugging: settings.developer_debugging,
+        recapture_process: None,
     };
 
     // Launch GUI and set the taskbar icon after creating the window


### PR DESCRIPTION
## Summary
- add a `RecaptureProcess` struct and field in `App`
- implement `start_recapture_all` and `handle_recapture_all`
- show a floating panel to recapture each window
- add "Recapture All" under the File menu
- initialize the new state in `main.rs`

## Testing
- `cargo check --target x86_64-pc-windows-gnu`

------
https://chatgpt.com/codex/tasks/task_e_68842447c600833286e73b4ea6c367c6