### PR TITLE
Add Recapture All option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ fn main() {
         last_layout_file: settings.last_layout_file.clone(),
         last_workspace_file: settings.last_workspace_file.clone(),
         developer_debugging: settings.developer_debugging,
+        recapture_progress: Arc::new(Mutex::new(None)),
     };
 
     // Launch GUI and set the taskbar icon after creating the window

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -979,3 +979,24 @@ pub fn listen_for_keys_with_dialog_and_window() -> Option<(&'static str, HWND, S
     }
     None
 }
+
+/// Waits for the user to press **Enter** or **Escape** without displaying a dialog box.
+///
+/// This is used by the "Recapture All" feature to allow the user to
+/// confirm or cancel capturing the currently active window while providing
+/// feedback through the GUI instead of a modal message box.
+pub fn wait_for_enter_or_escape() -> Option<&'static str> {
+    loop {
+        unsafe {
+            if GetAsyncKeyState(VK_RETURN.0 as i32) < 0 {
+                info!("Enter key detected.");
+                return Some("Enter");
+            }
+            if GetAsyncKeyState(VK_ESCAPE.0 as i32) < 0 {
+                info!("Escape key detected.");
+                return Some("Esc");
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}


### PR DESCRIPTION
## Summary
- add `Recapture All` command to the File menu
- display progress in a floating window while recapturing windows
- spawn background task to recapture each window
- provide helper `wait_for_enter_or_escape` for capturing without dialog

## Testing
- `cargo check --target x86_64-pc-windows-gnu`
- `cargo test --target x86_64-pc-windows-gnu` *(fails: Error calling dlltool `x86_64-w64-mingw32-dlltool`)*

------
https://chatgpt.com/codex/tasks/task_e_68842447c600833286e73b4ea6c367c6