### PR TITLE
Add Recapture All feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,8 @@ fn main() {
         last_layout_file: settings.last_layout_file.clone(),
         last_workspace_file: settings.last_workspace_file.clone(),
         developer_debugging: settings.developer_debugging,
+        recapture_status: Arc::new(Mutex::new(None)),
+        recapture_promise: Arc::new(Mutex::new(None)),
     };
 
     // Launch GUI and set the taskbar icon after creating the window

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -776,6 +776,19 @@ pub fn get_active_window() -> Option<(HWND, String)> {
     }
 }
 
+/// Find a window by its exact title.
+pub fn find_window_by_title(title: &str) -> Option<HWND> {
+    unsafe {
+        let wide: Vec<u16> = title.encode_utf16().chain(Some(0)).collect();
+        let hwnd = FindWindowW(None, PCWSTR(wide.as_ptr()));
+        if hwnd.0.is_null() {
+            None
+        } else {
+            Some(hwnd)
+        }
+    }
+}
+
 /// Repositions and resizes a window identified by `hwnd` to the coordinates `(x, y)` with dimensions `(w, h)`.
 ///
 /// # Behavior


### PR DESCRIPTION
## Summary
- add `Recapture All` option in File menu
- display status in floating window while recapturing
- search for windows by title to update handles
- update app initialization for new fields

## Testing
- `cargo check` *(fails: could not compile `multi-manager`)*

------
 