### PR TITLE
Add alias editing and display labels

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1198,18 +1198,18 @@ impl App {
         }
 
         if let Some(&(ws_idx, win_idx)) = self.recapture_queue.first() {
-            let (ws_name, win_title) = {
+            let (ws_name, win_label) = {
                 let workspaces = self.workspaces.lock().unwrap();
                 let ws_name = workspaces
                     .get(ws_idx)
                     .map(|w| w.name.clone())
                     .unwrap_or_default();
-                let win_title = workspaces
+                let win_label = workspaces
                     .get(ws_idx)
                     .and_then(|w| w.windows.get(win_idx))
-                    .map(|w| w.title.clone())
-                    .unwrap_or_default();
-                (ws_name, win_title)
+                    .map(|w| w.display_label())
+                    .unwrap_or_else(|| "Unknown window (no alias)".to_string());
+                (ws_name, win_label)
             };
 
             egui::Window::new("Recapture All")
@@ -1219,7 +1219,7 @@ impl App {
                 .show(ctx, |ui| {
                     ui.label(format!(
                         "Recapturing workspace '{}' window '{}'",
-                        ws_name, win_title
+                        ws_name, win_label
                     ));
                     ui.label("Focus the desired window and press Enter to capture, 'S' to skip, or Esc to cancel.");
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(windows, windows_subsystem = "windows")]
+#![windows_subsystem = "windows"]
 
 mod desktop_window_info;
 mod gui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![windows_subsystem = "windows"]
+#![cfg_attr(windows, windows_subsystem = "windows")]
 
 mod desktop_window_info;
 mod gui;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -373,11 +373,10 @@ impl Workspace {
                         .desired_width(200.0),
                 );
                 if response.changed() {
-                    let trimmed = alias_text.trim();
-                    window.alias = if trimmed.is_empty() {
+                    window.alias = if alias_text.trim().is_empty() {
                         None
                     } else {
-                        Some(trimmed.to_string())
+                        Some(alias_text.clone())
                     };
                     changed = true;
                 }
@@ -1065,5 +1064,23 @@ mod tests {
 
         with_alias.alias = None;
         assert_eq!(with_alias.display_label(), "Window Title (no alias)");
+
+        let mut with_trailing_space = Window {
+            id: 3,
+            title: "Keep Spaces".to_string(),
+            alias: Some("Alias With Space ".to_string()),
+            home: (0, 0, 100, 100),
+            target: (0, 0, 100, 100),
+            valid: true,
+        };
+        assert_eq!(with_trailing_space.display_label(), "Alias With Space ");
+        with_trailing_space.alias = Some("   ".to_string());
+        assert_eq!(
+            with_trailing_space
+                .alias
+                .as_deref()
+                .filter(|alias| !alias.trim().is_empty()),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add inline alias editing controls with alias-first labels for workspace windows and debug strings
- ensure recapture dialogs and context menus render window aliases with a fallback cue when not set
- add coverage for the alias display helper to lock in the visual-cue behavior

## Testing
- cargo fmt
- cargo test *(fails on non-Windows target: windows crate Win32 bindings unavailable in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69513c4050148332b3eeab3b3914bcdc)