### PR TITLE
Persist force recapture prompt setting and centralize settings persistence

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -45,6 +45,7 @@ pub struct App {
     pub last_workspace_file: Option<String>,
     pub last_bindings_file: Option<String>,
     pub developer_debugging: bool,
+    pub show_force_recapture_prompt: bool,
     pub recapture_queue: Vec<(usize, usize)>,
     pub recapture_active: bool,
 }
@@ -260,7 +261,13 @@ impl EframeApp for App {
         if self.save_on_exit {
             self.save_workspaces();
         }
-        save_settings(&Settings {
+        self.persist_settings();
+    }
+}
+
+impl App {
+    fn current_settings(&self) -> Settings {
+        Settings {
             save_on_exit: self.save_on_exit,
             auto_save: self.auto_save,
             log_level: self.log_level.clone(),
@@ -268,11 +275,14 @@ impl EframeApp for App {
             last_workspace_file: self.last_workspace_file.clone(),
             last_bindings_file: self.last_bindings_file.clone(),
             developer_debugging: self.developer_debugging,
-        });
+            show_force_recapture_prompt: self.show_force_recapture_prompt,
+        }
     }
-}
 
-impl App {
+    fn persist_settings(&self) {
+        save_settings(&self.current_settings());
+    }
+
     /// Renders the application's menu bar with a "File" menu.
     ///
     /// The menu contains a single "Settings" item that sets
@@ -294,15 +304,7 @@ impl App {
                                 .unwrap_or(default_path);
                             capture_all_desktops(&chosen);
                             self.last_layout_file = Some(chosen.clone());
-                            save_settings(&Settings {
-                                save_on_exit: self.save_on_exit,
-                                auto_save: self.auto_save,
-                                log_level: self.log_level.clone(),
-                                last_layout_file: self.last_layout_file.clone(),
-                                last_workspace_file: self.last_workspace_file.clone(),
-                                last_bindings_file: self.last_bindings_file.clone(),
-                                developer_debugging: self.developer_debugging,
-                            });
+                            self.persist_settings();
                             show_message_box("Desktops saved", "Save");
                             ui.close_menu();
                         }
@@ -318,15 +320,7 @@ impl App {
                                 .unwrap_or(default_path);
                             restore_all_desktops(&chosen);
                             self.last_layout_file = Some(chosen.clone());
-                            save_settings(&Settings {
-                                save_on_exit: self.save_on_exit,
-                                auto_save: self.auto_save,
-                                log_level: self.log_level.clone(),
-                                last_layout_file: self.last_layout_file.clone(),
-                                last_workspace_file: self.last_workspace_file.clone(),
-                                last_bindings_file: self.last_bindings_file.clone(),
-                                developer_debugging: self.developer_debugging,
-                            });
+                            self.persist_settings();
                             ui.close_menu();
                         }
                         if ui.button("Move All to Origin").clicked() {
@@ -853,18 +847,11 @@ impl App {
     pub fn save_workspaces_to_file(&mut self, path: &str) {
         let workspaces = self.workspaces.lock().unwrap();
         save_workspaces(&workspaces, path);
+        drop(workspaces);
         self.last_workspace_file = Some(path.to_string());
         self.unsaved_changes = false;
         info!("Workspaces saved successfully.");
-        save_settings(&Settings {
-            save_on_exit: self.save_on_exit,
-            auto_save: self.auto_save,
-            log_level: self.log_level.clone(),
-            last_layout_file: self.last_layout_file.clone(),
-            last_workspace_file: self.last_workspace_file.clone(),
-            last_bindings_file: self.last_bindings_file.clone(),
-            developer_debugging: self.developer_debugging,
-        });
+        self.persist_settings();
     }
 
     fn save_window_bindings_to_file(&mut self, path: &str) -> Result<usize, WindowBindingError> {
@@ -874,15 +861,7 @@ impl App {
 
         if result.is_ok() {
             self.last_bindings_file = Some(path.to_string());
-            save_settings(&Settings {
-                save_on_exit: self.save_on_exit,
-                auto_save: self.auto_save,
-                log_level: self.log_level.clone(),
-                last_layout_file: self.last_layout_file.clone(),
-                last_workspace_file: self.last_workspace_file.clone(),
-                last_bindings_file: self.last_bindings_file.clone(),
-                developer_debugging: self.developer_debugging,
-            });
+            self.persist_settings();
         }
 
         result
@@ -1020,40 +999,16 @@ impl App {
             .show(ctx, |ui| {
                 let response = ui.checkbox(&mut self.save_on_exit, "Save on exit");
                 if response.changed() {
-                    save_settings(&Settings {
-                        save_on_exit: self.save_on_exit,
-                        auto_save: self.auto_save,
-                        log_level: self.log_level.clone(),
-                        last_layout_file: None,
-                        last_workspace_file: self.last_workspace_file.clone(),
-                        last_bindings_file: self.last_bindings_file.clone(),
-                        developer_debugging: self.developer_debugging,
-                    });
+                    self.persist_settings();
                 }
                 let auto_response = ui.checkbox(&mut self.auto_save, "Auto-save");
                 if auto_response.changed() {
-                    save_settings(&Settings {
-                        save_on_exit: self.save_on_exit,
-                        auto_save: self.auto_save,
-                        log_level: self.log_level.clone(),
-                        last_layout_file: self.last_layout_file.clone(),
-                        last_workspace_file: self.last_workspace_file.clone(),
-                        last_bindings_file: self.last_bindings_file.clone(),
-                        developer_debugging: self.developer_debugging,
-                    });
+                    self.persist_settings();
                 }
                 let dev_response =
                     ui.checkbox(&mut self.developer_debugging, "Developer Debugging");
                 if dev_response.changed() {
-                    save_settings(&Settings {
-                        save_on_exit: self.save_on_exit,
-                        auto_save: self.auto_save,
-                        log_level: self.log_level.clone(),
-                        last_layout_file: self.last_layout_file.clone(),
-                        last_workspace_file: self.last_workspace_file.clone(),
-                        last_bindings_file: self.last_bindings_file.clone(),
-                        developer_debugging: self.developer_debugging,
-                    });
+                    self.persist_settings();
                 }
                 let mut changed = false;
                 egui::ComboBox::from_label("Log Level")
@@ -1069,15 +1024,7 @@ impl App {
                         }
                     });
                 if changed {
-                    save_settings(&Settings {
-                        save_on_exit: self.save_on_exit,
-                        auto_save: self.auto_save,
-                        log_level: self.log_level.clone(),
-                        last_layout_file: self.last_layout_file.clone(),
-                        last_workspace_file: self.last_workspace_file.clone(),
-                        last_bindings_file: self.last_bindings_file.clone(),
-                        developer_debugging: self.developer_debugging,
-                    });
+                    self.persist_settings();
                 }
                 let mut path = self.last_layout_file.clone().unwrap_or_default();
                 ui.horizontal(|ui| {
@@ -1088,15 +1035,7 @@ impl App {
                         } else {
                             self.last_layout_file = Some(path.clone());
                         }
-                        save_settings(&Settings {
-                            save_on_exit: self.save_on_exit,
-                            auto_save: self.auto_save,
-                            log_level: self.log_level.clone(),
-                            last_layout_file: self.last_layout_file.clone(),
-                            last_workspace_file: self.last_workspace_file.clone(),
-                            last_bindings_file: self.last_bindings_file.clone(),
-                            developer_debugging: self.developer_debugging,
-                        });
+                        self.persist_settings();
                     }
                 });
                 let mut bindings_path = self.last_bindings_file.clone().unwrap_or_default();
@@ -1108,15 +1047,7 @@ impl App {
                         } else {
                             self.last_bindings_file = Some(bindings_path.clone());
                         }
-                        save_settings(&Settings {
-                            save_on_exit: self.save_on_exit,
-                            auto_save: self.auto_save,
-                            log_level: self.log_level.clone(),
-                            last_layout_file: self.last_layout_file.clone(),
-                            last_workspace_file: self.last_workspace_file.clone(),
-                            last_bindings_file: self.last_bindings_file.clone(),
-                            developer_debugging: self.developer_debugging,
-                        });
+                        self.persist_settings();
                     }
                 });
                 if ui.button("Close").clicked() {
@@ -1305,15 +1236,7 @@ impl App {
 
         self.last_workspace_file = Some(path.to_string());
         self.unsaved_changes = false;
-        save_settings(&Settings {
-            save_on_exit: self.save_on_exit,
-            auto_save: self.auto_save,
-            log_level: self.log_level.clone(),
-            last_layout_file: self.last_layout_file.clone(),
-            last_workspace_file: self.last_workspace_file.clone(),
-            last_bindings_file: self.last_bindings_file.clone(),
-            developer_debugging: self.developer_debugging,
-        });
+        self.persist_settings();
 
         let bindings_path = self
             .last_bindings_file

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,7 @@ fn main() {
         last_workspace_file: settings.last_workspace_file.clone(),
         last_bindings_file: settings.last_bindings_file.clone(),
         developer_debugging: settings.developer_debugging,
+        show_force_recapture_prompt: settings.show_force_recapture_prompt,
         recapture_queue: Vec::new(),
         recapture_active: false,
     };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -27,6 +27,13 @@ pub struct Settings {
     /// If `true`, additional developer debugging information is shown.
     #[serde(default)]
     pub developer_debugging: bool,
+    /// If `true`, the user should be prompted before forced recapture actions.
+    #[serde(default = "default_show_force_recapture_prompt")]
+    pub show_force_recapture_prompt: bool,
+}
+
+fn default_show_force_recapture_prompt() -> bool {
+    false
 }
 
 impl Default for Settings {
@@ -40,6 +47,7 @@ impl Default for Settings {
             last_workspace_file: None,
             last_bindings_file: None,
             developer_debugging: false,
+            show_force_recapture_prompt: false,
         }
     }
 }
@@ -99,6 +107,7 @@ mod tests {
             last_workspace_file: Some("work.json".into()),
             last_bindings_file: Some("bindings.json".into()),
             developer_debugging: true,
+            show_force_recapture_prompt: true,
         };
         save_settings(&settings);
         let loaded = load_settings();
@@ -110,6 +119,7 @@ mod tests {
         assert_eq!(loaded.last_workspace_file.as_deref(), Some("work.json"));
         assert_eq!(loaded.last_bindings_file.as_deref(), Some("bindings.json"));
         assert_eq!(loaded.developer_debugging, true);
+        assert_eq!(loaded.show_force_recapture_prompt, true);
     }
 
     #[test]
@@ -124,6 +134,7 @@ mod tests {
             last_workspace_file: None,
             last_bindings_file: None,
             developer_debugging: false,
+            show_force_recapture_prompt: false,
         };
         save_settings(&settings);
         let loaded = load_settings();
@@ -135,5 +146,6 @@ mod tests {
         assert_eq!(loaded.last_workspace_file, None);
         assert_eq!(loaded.last_bindings_file, None);
         assert_eq!(loaded.developer_debugging, false);
+        assert_eq!(loaded.show_force_recapture_prompt, false);
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -958,6 +958,7 @@ mod tests {
             last_workspace_file: None,
             last_bindings_file: None,
             developer_debugging: false,
+            show_force_recapture_prompt: false,
             recapture_queue: Vec::new(),
             recapture_active: false,
         }


### PR DESCRIPTION
### Motivation
- Add a new persistent setting to control whether the user is prompted before forced recapture actions so that this preference survives restarts. 
- Reduce duplication and the risk of missing fields when persisting settings by centralizing Settings construction and save logic in the GUI.

### Description
- Added `show_force_recapture_prompt: bool` to `Settings` with `#[serde(default = "default_show_force_recapture_prompt")]` and helper `fn default_show_force_recapture_prompt() -> bool { false }`, and included it in `Default` and the settings round-trip tests (file: `src/settings.rs`).
- Added `pub show_force_recapture_prompt: bool` to the `App` struct and updated all initialization sites to set the field (notably in `src/main.rs` and the test constructor in `src/workspace.rs`).
- Introduced `fn current_settings(&self) -> Settings` and `fn persist_settings(&self)` on `impl App` in `src/gui.rs` to produce a complete `Settings` instance from the live `App` state and save it.
- Replaced repeated inline `save_settings(&Settings { ... })` blocks in the GUI with `self.persist_settings()` at the save sites, including `on_exit`, desktop layout save/restore, workspace save/load, settings window toggles, and window bindings save/load (file: `src/gui.rs`).

### Testing
- Ran `cargo fmt -- --check` which succeeded.
- Ran `git diff --check` which reported no issues.
- Ran `cargo test` with the default toolchain which failed because the `image` crate requires a newer Rust (`rustc 1.88.0`) than the environment default (`1.87.0`).
- Ran tests with `cargo +1.88.0 test`; compilation progressed but the test run failed in this (Linux) environment due to Windows-only `windows::Win32` API imports in the crate (these are expected platform-specific failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2484aec10083328587d713815c8110)