### PR TITLE
Add force recapture prompt setting checkbox

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1010,6 +1010,17 @@ impl App {
                 if dev_response.changed() {
                     self.persist_settings();
                 }
+                let force_recapture_prompt_response = ui
+                    .checkbox(
+                        &mut self.show_force_recapture_prompt,
+                        "Show force recapture confirmation prompt",
+                    )
+                    .on_hover_text(
+                        "When disabled, recapture starts immediately and listens globally for Enter to confirm or Escape to cancel.",
+                    );
+                if force_recapture_prompt_response.changed() {
+                    self.persist_settings();
+                }
                 let mut changed = false;
                 egui::ComboBox::from_label("Log Level")
                     .selected_text(&self.log_level)


### PR DESCRIPTION
### Motivation

- Provide a user-facing toggle to choose between the existing modal confirmation and a non-modal global Enter/Escape capture for force recapture behavior.

### Description

- Added a checkbox in `render_settings_window` bound to `self.show_force_recapture_prompt` with the label `Show force recapture confirmation prompt`.
- Attached hover text: `When disabled, recapture starts immediately and listens globally for Enter to confirm or Escape to cancel.`
- Call `self.persist_settings()` when the checkbox value changes and do not modify `recapture_active`, the recapture queue, or any in-progress recapture flow.

### Testing

- Ran `cargo fmt` which completed without errors.
- Attempted `cargo test` but it failed to run because the environment uses `rustc 1.87.0` while `image@0.25.10` requires `rustc 1.88.0`.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a248764988c8332bb87186c64afc29c)