### PR TITLE
Add pending manual capture workflow

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -5,8 +5,9 @@ use crate::window_bindings::{
     WindowBindingError,
 };
 use crate::window_manager::{
-    capture_all_desktops, check_hotkeys, get_active_window, move_all_to_origin,
-    poll_recapture_keys, restore_all_desktops, send_all_windows_home, RecaptureAction,
+    capture_all_desktops, check_hotkeys, get_active_window, get_window_position,
+    move_all_to_origin, poll_recapture_keys, restore_all_desktops, send_all_windows_home,
+    RecaptureAction,
 };
 use crate::workspace::*;
 use eframe::egui::ViewportBuilder;
@@ -15,7 +16,6 @@ use eframe::NativeOptions;
 use eframe::{self, App as EframeApp};
 use log::{debug, info, warn};
 use poll_promise::Promise;
-use rfd::FileDialog;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::{Arc, Mutex};
@@ -23,6 +23,21 @@ use std::thread;
 use std::time::{Duration, Instant};
 use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::WindowsAndMessaging::IsWindow;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PendingCaptureAction {
+    ForceRecaptureWindow {
+        workspace_index: usize,
+        window_index: usize,
+    },
+    RecaptureInvalidWindow {
+        workspace_index: usize,
+        window_index: usize,
+    },
+    CaptureActiveWindow {
+        workspace_index: usize,
+    },
+}
 
 #[derive(Clone)]
 pub struct App {
@@ -46,8 +61,16 @@ pub struct App {
     pub last_bindings_file: Option<String>,
     pub developer_debugging: bool,
     pub show_force_recapture_prompt: bool,
+    pub pending_capture_action: Option<PendingCaptureAction>,
     pub recapture_queue: Vec<(usize, usize)>,
     pub recapture_active: bool,
+}
+
+pub fn pending_indicator_visible(
+    show_force_recapture_prompt: bool,
+    pending_capture_action: &Option<PendingCaptureAction>,
+) -> bool {
+    !show_force_recapture_prompt && pending_capture_action.is_some()
 }
 
 pub struct WorkspaceControlContext<'a> {
@@ -56,6 +79,20 @@ pub struct WorkspaceControlContext<'a> {
     pub move_down_index: &'a mut Option<usize>,
     pub workspaces_len: usize,
     pub index: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{pending_indicator_visible, PendingCaptureAction};
+
+    #[test]
+    fn pending_indicator_visible_only_for_pending_promptless_capture() {
+        let action = Some(PendingCaptureAction::CaptureActiveWindow { workspace_index: 0 });
+
+        assert!(pending_indicator_visible(false, &action));
+        assert!(!pending_indicator_visible(true, &action));
+        assert!(!pending_indicator_visible(false, &None));
+    }
 }
 
 //
@@ -238,6 +275,10 @@ impl EframeApp for App {
             self.process_recapture_all(ctx);
         }
 
+        if self.pending_capture_action.is_some() {
+            self.process_pending_capture(ctx);
+        }
+
         if save_flag {
             self.save_workspaces();
         }
@@ -266,6 +307,90 @@ impl EframeApp for App {
 }
 
 impl App {
+    pub fn start_pending_capture(&mut self, action: PendingCaptureAction) {
+        self.pending_capture_action = Some(action);
+        let _ = poll_recapture_keys();
+    }
+
+    pub fn cancel_pending_capture(&mut self) {
+        self.pending_capture_action = None;
+        let _ = poll_recapture_keys();
+    }
+
+    pub fn is_waiting_for_manual_capture(&self) -> bool {
+        pending_indicator_visible(
+            self.show_force_recapture_prompt,
+            &self.pending_capture_action,
+        )
+    }
+
+    fn process_pending_capture(&mut self, ctx: &egui::Context) {
+        let Some(action) = self.pending_capture_action.clone() else {
+            return;
+        };
+
+        if let Some(recapture_action) = poll_recapture_keys() {
+            match recapture_action {
+                RecaptureAction::Confirm => {
+                    self.confirm_pending_capture(action);
+                    self.pending_capture_action = None;
+                    let _ = poll_recapture_keys();
+                }
+                RecaptureAction::Cancel => self.cancel_pending_capture(),
+                RecaptureAction::Skip => {}
+            }
+        }
+
+        ctx.request_repaint();
+    }
+
+    fn confirm_pending_capture(&mut self, action: PendingCaptureAction) {
+        match action {
+            PendingCaptureAction::ForceRecaptureWindow {
+                workspace_index,
+                window_index,
+            }
+            | PendingCaptureAction::RecaptureInvalidWindow {
+                workspace_index,
+                window_index,
+            } => {
+                if let Some((new_hwnd, new_title)) = get_active_window() {
+                    let mut workspaces = self.workspaces.lock().unwrap();
+                    if let Some(workspace) = workspaces.get_mut(workspace_index) {
+                        if let Some(window) = workspace.windows.get_mut(window_index) {
+                            window.id = new_hwnd.0 as usize;
+                            window.title = new_title;
+                            window.valid = true;
+                            window.sync_alias_from_title_if_missing();
+                            self.unsaved_changes = true;
+                        }
+                    }
+                } else {
+                    warn!("Pending capture confirmed, but no active window was detected.");
+                }
+            }
+            PendingCaptureAction::CaptureActiveWindow { workspace_index } => {
+                if let Some((hwnd, title)) = get_active_window() {
+                    let rect = get_window_position(hwnd).unwrap_or((0, 0, 800, 600));
+                    let mut workspaces = self.workspaces.lock().unwrap();
+                    if let Some(workspace) = workspaces.get_mut(workspace_index) {
+                        workspace.windows.push(Window {
+                            id: hwnd.0 as usize,
+                            title,
+                            alias: None,
+                            home: rect,
+                            target: rect,
+                            valid: true,
+                        });
+                        self.unsaved_changes = true;
+                    }
+                } else {
+                    warn!("Pending capture confirmed, but no active window was detected.");
+                }
+            }
+        }
+    }
+
     fn current_settings(&self) -> Settings {
         Settings {
             save_on_exit: self.save_on_exit,
@@ -453,7 +578,15 @@ impl App {
         _save_flag: &mut bool,
         new_workspace: &mut Option<Workspace>,
     ) {
-        ui.heading(&self.app_title_name);
+        ui.horizontal(|ui| {
+            ui.heading(&self.app_title_name);
+            if self.is_waiting_for_manual_capture() {
+                ui.colored_label(
+                    egui::Color32::BLUE,
+                    "Waiting for force recapture: Enter to confirm, Esc to cancel",
+                );
+            }
+        });
         ui.horizontal(|ui| {
             if ui.button("Add New Workspace").clicked() {
                 let workspaces = self.workspaces.lock().unwrap();
@@ -520,6 +653,7 @@ impl App {
 
         let mut any_changed = false;
         let mut requested_hotkey: Option<usize> = None;
+        let mut pending_capture_action: Option<PendingCaptureAction> = None;
         egui::ScrollArea::both()
             .auto_shrink([false; 2])
             .show(ui, |ui| {
@@ -552,12 +686,16 @@ impl App {
                             });
                         })
                         .body(|ui| {
-                            let (changed, open_dialog) = workspace.render_details(ui, self);
+                            let (changed, open_dialog, pending_action) =
+                                workspace.render_details(ui, self, i);
                             if changed {
                                 any_changed = true;
                             }
                             if open_dialog {
                                 requested_hotkey = Some(i);
+                            }
+                            if pending_capture_action.is_none() {
+                                pending_capture_action = pending_action;
                             }
 
                             let mut context = WorkspaceControlContext {
@@ -584,6 +722,10 @@ impl App {
             });
         if any_changed {
             self.unsaved_changes = true;
+        }
+
+        if let Some(action) = pending_capture_action {
+            self.start_pending_capture(action);
         }
 
         // Reset expand_all_signal after use

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ fn main() {
         last_bindings_file: settings.last_bindings_file.clone(),
         developer_debugging: settings.developer_debugging,
         show_force_recapture_prompt: settings.show_force_recapture_prompt,
+        pending_capture_action: None,
         recapture_queue: Vec::new(),
         recapture_active: false,
     };

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,8 +1,7 @@
-use crate::gui::App;
+use crate::gui::{App, PendingCaptureAction};
 use crate::hotkey::Hotkey;
 use crate::window_manager::get_window_position;
 use crate::window_manager::is_window_at_position;
-use crate::window_manager::listen_for_keys_with_dialog_and_window;
 use crate::window_manager::move_window;
 use crate::window_manager::move_window_to_origin;
 use crate::window_manager::*;
@@ -146,9 +145,15 @@ impl Workspace {
     ///
     /// The `app` reference is required so that the hotkey can be unregistered
     /// when resetting it back to the default state.
-    pub fn render_details(&mut self, ui: &mut egui::Ui, app: &App) -> (bool, bool) {
+    pub fn render_details(
+        &mut self,
+        ui: &mut egui::Ui,
+        app: &App,
+        workspace_index: usize,
+    ) -> (bool, bool, Option<PendingCaptureAction>) {
         let mut changed = false;
         let mut open_dialog = false;
+        let mut pending_capture_action = None;
         // Hotkey section
         ui.horizontal(|ui| {
             ui.label("Hotkey:");
@@ -307,24 +312,34 @@ impl Workspace {
                             // Add the "Force Recapture" button
                             if ui.button("Force Recapture").clicked() {
                                 info!("Force Recapture triggered for HWND: {:?}", window.id);
-                                if let Some("Enter") = listen_for_keys_with_dialog() {
+                                if app.show_force_recapture_prompt {
+                                    if let Some("Enter") = listen_for_keys_with_dialog() {
                                         if let Some((new_hwnd, new_title)) = get_active_window() {
                                             // Update the HWND and title
                                             window.id = new_hwnd.0 as usize;
                                             window.title = new_title;
+                                            window.valid = true;
                                             window.sync_alias_from_title_if_missing();
                                             info!(
                                                 "Force Recaptured window '{}', new HWND: {:?}",
                                                 window.display_label(), new_hwnd
                                             );
-                                    } else {
-                                        warn!("Force Recapture canceled or no active window detected.");
+                                            changed = true;
+                                        } else {
+                                            warn!("Force Recapture canceled or no active window detected.");
+                                        }
                                     }
+                                } else {
+                                    pending_capture_action = Some(
+                                        PendingCaptureAction::ForceRecaptureWindow {
+                                            workspace_index,
+                                            window_index: i,
+                                        },
+                                    );
                                 }
 
                                 // Explicitly close the popup after the action
                                 ui.memory_mut(|mem| mem.close_popup());
-                                changed = true;
                             }
 
                             if ui.button("Swap Home/Target").clicked() {
@@ -346,20 +361,30 @@ impl Workspace {
         } else {
                 ui.colored_label(egui::Color32::RED, format!("HWND: {:?}", window.id));
                 if ui.button("Recapture").clicked() {
-                    if let Some("Enter") = listen_for_keys_with_dialog() {
-                        if let Some((new_hwnd, new_title)) = get_active_window() {
-                            // Update the invalid window with the new HWND but retain home/target
-                            window.id = new_hwnd.0 as usize;
-                            window.title = new_title;
-                            window.sync_alias_from_title_if_missing();
-                            info!(
-                                "Recaptured window '{}', new HWND: {:?}",
-                                window.display_label(), new_hwnd
-                                );
-                            changed = true;
-                        } else {
-                            warn!("Recapture canceled or no active window detected.");
+                    if app.show_force_recapture_prompt {
+                        if let Some("Enter") = listen_for_keys_with_dialog() {
+                            if let Some((new_hwnd, new_title)) = get_active_window() {
+                                // Update the invalid window with the new HWND but retain home/target
+                                window.id = new_hwnd.0 as usize;
+                                window.title = new_title;
+                                window.valid = true;
+                                window.sync_alias_from_title_if_missing();
+                                info!(
+                                    "Recaptured window '{}', new HWND: {:?}",
+                                    window.display_label(), new_hwnd
+                                    );
+                                changed = true;
+                            } else {
+                                warn!("Recapture canceled or no active window detected.");
+                            }
                         }
+                    } else {
+                        pending_capture_action = Some(
+                            PendingCaptureAction::RecaptureInvalidWindow {
+                                workspace_index,
+                                window_index: i,
+                            },
+                        );
                     }
                 }
                 }
@@ -403,21 +428,26 @@ impl Workspace {
 
         // Capture active window button
         if ui.button("Capture Active Window").clicked() {
-            if let Some(("Enter", hwnd, title)) = listen_for_keys_with_dialog_and_window() {
-                let rect = get_window_position(hwnd).unwrap_or((0, 0, 800, 600));
-                self.windows.push(Window {
-                    id: hwnd.0 as usize,
-                    title,
-                    alias: None,
-                    home: rect,
-                    target: rect,
-                    valid: true,
-                });
-                changed = true;
+            if app.show_force_recapture_prompt {
+                if let Some(("Enter", hwnd, title)) = listen_for_keys_with_dialog_and_window() {
+                    let rect = get_window_position(hwnd).unwrap_or((0, 0, 800, 600));
+                    self.windows.push(Window {
+                        id: hwnd.0 as usize,
+                        title,
+                        alias: None,
+                        home: rect,
+                        target: rect,
+                        valid: true,
+                    });
+                    changed = true;
+                }
+            } else {
+                pending_capture_action =
+                    Some(PendingCaptureAction::CaptureActiveWindow { workspace_index });
             }
         }
 
-        (changed, open_dialog)
+        (changed, open_dialog, pending_capture_action)
     }
 
     /// Attaches a context menu to a UI widget.
@@ -959,6 +989,7 @@ mod tests {
             last_bindings_file: None,
             developer_debugging: false,
             show_force_recapture_prompt: false,
+            pending_capture_action: None,
             recapture_queue: Vec::new(),
             recapture_active: false,
         }


### PR DESCRIPTION
### Motivation
- Support promptless (disabled-prompt) manual captures by queuing a pending action instead of blocking with a dialog or manipulating the app window.
- Provide a small lifecycle for pending captures so the UI can show a non-blocking indicator and confirm/cancel via global Enter/Esc keys.

### Description
- Added `PendingCaptureAction` enum and `pub pending_capture_action: Option<PendingCaptureAction>` on `App`, and a pure helper `pending_indicator_visible(show_force_recapture_prompt: bool, pending_capture_action: &Option<PendingCaptureAction>) -> bool` to determine indicator visibility.
- Implemented `App::start_pending_capture`, `App::cancel_pending_capture`, `App::is_waiting_for_manual_capture`, per-frame `process_pending_capture` and `confirm_pending_capture` that only call `get_active_window()` when Enter is confirmed, update window id/title/valid/alias, push new `Window` for active captures, set `unsaved_changes = true`, and always call `ctx.request_repaint()` while pending.
- Updated `App::update` to call `process_pending_capture(ctx)` each frame while `pending_capture_action.is_some()`, and updated `render_header` to render the blue guide text when `is_waiting_for_manual_capture()` is true.
- Modified `Workspace::render_details` to return an optional `PendingCaptureAction` and route three actions into pending mode when `show_force_recapture_prompt` is disabled: force recapture on existing window, recapture invalid window, and capture active window; preserved existing blocking behavior when the prompt is enabled.
- Initialized `pending_capture_action: None` in manual `App` constructions in `src/main.rs` and `src/workspace.rs::test_app()` and adjusted call sites to wire the pending action into `App::start_pending_capture`.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo +1.88.0 check --target x86_64-pc-windows-gnu` which completed successfully (Windows target check used for windows APIs).
- Running `cargo test` with the default toolchain failed due to the local default `rustc 1.87.0` while `image@0.25.10` requires `rustc 1.88.0` (toolchain mismatch).
- Attempting `cargo +1.88.0 test --target x86_64-pc-windows-gnu --no-run` was blocked by a missing cross-tool `x86_64-w64-mingw32-dlltool` in the environment, so full test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24891d8f54833293acdd45a955c3e4)