### PR TITLE
Defer workspace capture commands

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -312,6 +312,24 @@ impl App {
         let _ = poll_recapture_keys();
     }
 
+    pub fn start_force_recapture(&mut self, workspace_index: usize, window_index: usize) {
+        self.start_pending_capture(PendingCaptureAction::ForceRecaptureWindow {
+            workspace_index,
+            window_index,
+        });
+    }
+
+    pub fn start_invalid_recapture(&mut self, workspace_index: usize, window_index: usize) {
+        self.start_pending_capture(PendingCaptureAction::RecaptureInvalidWindow {
+            workspace_index,
+            window_index,
+        });
+    }
+
+    pub fn start_capture_active_window(&mut self, workspace_index: usize) {
+        self.start_pending_capture(PendingCaptureAction::CaptureActiveWindow { workspace_index });
+    }
+
     pub fn cancel_pending_capture(&mut self) {
         self.pending_capture_action = None;
         let _ = poll_recapture_keys();
@@ -653,7 +671,7 @@ impl App {
 
         let mut any_changed = false;
         let mut requested_hotkey: Option<usize> = None;
-        let mut pending_capture_action: Option<PendingCaptureAction> = None;
+        let mut workspace_commands = Vec::new();
         egui::ScrollArea::both()
             .auto_shrink([false; 2])
             .show(ui, |ui| {
@@ -686,7 +704,7 @@ impl App {
                             });
                         })
                         .body(|ui| {
-                            let (changed, open_dialog, pending_action) =
+                            let (changed, open_dialog, commands) =
                                 workspace.render_details(ui, self, i);
                             if changed {
                                 any_changed = true;
@@ -694,9 +712,7 @@ impl App {
                             if open_dialog {
                                 requested_hotkey = Some(i);
                             }
-                            if pending_capture_action.is_none() {
-                                pending_capture_action = pending_action;
-                            }
+                            workspace_commands.extend(commands);
 
                             let mut context = WorkspaceControlContext {
                                 workspace_to_delete,
@@ -724,8 +740,20 @@ impl App {
             self.unsaved_changes = true;
         }
 
-        if let Some(action) = pending_capture_action {
-            self.start_pending_capture(action);
+        for command in workspace_commands {
+            match command {
+                WorkspaceUiCommand::StartForceRecapture {
+                    workspace_index,
+                    window_index,
+                } => self.start_force_recapture(workspace_index, window_index),
+                WorkspaceUiCommand::StartInvalidRecapture {
+                    workspace_index,
+                    window_index,
+                } => self.start_invalid_recapture(workspace_index, window_index),
+                WorkspaceUiCommand::StartCaptureActiveWindow { workspace_index } => {
+                    self.start_capture_active_window(workspace_index);
+                }
+            }
         }
 
         // Reset expand_all_signal after use

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,4 +1,4 @@
-use crate::gui::{App, PendingCaptureAction};
+use crate::gui::App;
 use crate::hotkey::Hotkey;
 use crate::window_manager::get_window_position;
 use crate::window_manager::is_window_at_position;
@@ -19,6 +19,22 @@ use windows::Win32::UI::WindowsAndMessaging::IsWindow;
 static HOTKEY_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:F(?:[1-9]|1[0-2]|1[3-9]|2[0-4])|[A-Z]|[0-9]|NUMPAD[0-9]|NUMPAD(?:MULTIPLY|ADD|SEPARATOR|SUBTRACT|DOT|DIVIDE)|UP|DOWN|LEFT|RIGHT|BACKSPACE|TAB|ENTER|PAUSE|CAPSLOCK|ESCAPE|SPACE|PAGEUP|PAGEDOWN|END|HOME|INSERT|DELETE|OEM_(?:PLUS|COMMA|MINUS|PERIOD|[1-7])|PRINTSCREEN|SCROLLLOCK|NUMLOCK|LEFT(?:SHIFT|CTRL|ALT)|RIGHT(?:SHIFT|CTRL|ALT))$").unwrap()
 });
+
+/// Commands emitted by workspace UI controls for the application to handle after rendering.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkspaceUiCommand {
+    StartForceRecapture {
+        workspace_index: usize,
+        window_index: usize,
+    },
+    StartInvalidRecapture {
+        workspace_index: usize,
+        window_index: usize,
+    },
+    StartCaptureActiveWindow {
+        workspace_index: usize,
+    },
+}
 
 /// Represents a workspace, which groups multiple windows and allows toggling between specific positions.
 ///
@@ -150,10 +166,10 @@ impl Workspace {
         ui: &mut egui::Ui,
         app: &App,
         workspace_index: usize,
-    ) -> (bool, bool, Option<PendingCaptureAction>) {
+    ) -> (bool, bool, Vec<WorkspaceUiCommand>) {
         let mut changed = false;
         let mut open_dialog = false;
-        let mut pending_capture_action = None;
+        let mut commands = Vec::new();
         // Hotkey section
         ui.horizontal(|ui| {
             ui.label("Hotkey:");
@@ -330,12 +346,10 @@ impl Workspace {
                                         }
                                     }
                                 } else {
-                                    pending_capture_action = Some(
-                                        PendingCaptureAction::ForceRecaptureWindow {
-                                            workspace_index,
-                                            window_index: i,
-                                        },
-                                    );
+                                    commands.push(WorkspaceUiCommand::StartForceRecapture {
+                                        workspace_index,
+                                        window_index: i,
+                                    });
                                 }
 
                                 // Explicitly close the popup after the action
@@ -379,12 +393,10 @@ impl Workspace {
                             }
                         }
                     } else {
-                        pending_capture_action = Some(
-                            PendingCaptureAction::RecaptureInvalidWindow {
-                                workspace_index,
-                                window_index: i,
-                            },
-                        );
+                        commands.push(WorkspaceUiCommand::StartInvalidRecapture {
+                            workspace_index,
+                            window_index: i,
+                        });
                     }
                 }
                 }
@@ -442,12 +454,11 @@ impl Workspace {
                     changed = true;
                 }
             } else {
-                pending_capture_action =
-                    Some(PendingCaptureAction::CaptureActiveWindow { workspace_index });
+                commands.push(WorkspaceUiCommand::StartCaptureActiveWindow { workspace_index });
             }
         }
 
-        (changed, open_dialog, pending_capture_action)
+        (changed, open_dialog, commands)
     }
 
     /// Attaches a context menu to a UI widget.


### PR DESCRIPTION
### Motivation

- Prevent invoking modal/pending capture helpers while holding the workspace mutex by deferring promptless capture requests to be processed after rendering finishes.
- Preserve existing modal behavior when `show_force_recapture_prompt` is enabled while providing a promptless path that emits commands instead of starting captures directly.

### Description

- Added `WorkspaceUiCommand` enum with `StartForceRecapture { workspace_index, window_index }`, `StartInvalidRecapture { workspace_index, window_index }`, and `StartCaptureActiveWindow { workspace_index }` in `src/workspace.rs`.
- Changed `Workspace::render_details` signature to return `(bool, bool, Vec<WorkspaceUiCommand>)`, created `let mut commands = Vec::new();`, and push appropriate `WorkspaceUiCommand` variants when `app.show_force_recapture_prompt` is `false`, while preserving the existing modal `listen_for_keys_*` behavior when `true`.
- Added `App` helper methods `start_force_recapture`, `start_invalid_recapture`, and `start_capture_active_window` in `src/gui.rs`, modified `render_workspace_list` to collect commands while holding the workspace mutex and then process those commands after the mutex guard is dropped by invoking the new helpers, avoiding passing a mutable `App` into `render_details` while the workspace lock is held.

### Testing

- Ran `cargo fmt` which completed successfully.
- Ran `git diff --check` which completed without issues.
- Ran `cargo +1.88.0 check --locked --target x86_64-pc-windows-gnu` which completed successfully for the Windows-targeted build; note that `cargo check --locked` on the default Linux toolchain failed due to `image@0.25.10` requiring Rust 1.88.0 and a non-Windows host cannot resolve `windows::Win32` symbols when targeting the host platform.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a249220b7f483328e9bef26e79f64cf)