### PR TITLE
Add settings backward-compat and pending-capture tests; add test seam to avoid keyboard polling

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -81,9 +81,49 @@ pub struct WorkspaceControlContext<'a> {
     pub index: usize,
 }
 
+#[cfg(not(test))]
+fn clear_recapture_key_state() {
+    let _ = poll_recapture_keys();
+}
+
+#[cfg(test)]
+fn clear_recapture_key_state() {}
+
 #[cfg(test)]
 mod tests {
-    use super::{pending_indicator_visible, PendingCaptureAction};
+    use super::{pending_indicator_visible, App, PendingCaptureAction};
+    use crate::workspace::Workspace;
+    use poll_promise::Promise;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn test_app() -> App {
+        App {
+            app_title_name: "Multi Manager".to_string(),
+            workspaces: Arc::new(Mutex::new(Vec::<Workspace>::new())),
+            last_hotkey_info: Arc::new(Mutex::new(None)),
+            hotkey_promise: Arc::new(Mutex::new(None::<Promise<()>>)),
+            initial_validation_done: Arc::new(Mutex::new(false)),
+            registered_hotkeys: Arc::new(Mutex::new(HashMap::new())),
+            rename_dialog: None,
+            hotkey_dialog: None,
+            all_expanded: false,
+            expand_all_signal: None,
+            show_settings: false,
+            auto_save: false,
+            unsaved_changes: false,
+            save_on_exit: false,
+            log_level: "info".to_string(),
+            last_layout_file: None,
+            last_workspace_file: None,
+            last_bindings_file: None,
+            developer_debugging: false,
+            show_force_recapture_prompt: false,
+            pending_capture_action: None,
+            recapture_queue: Vec::new(),
+            recapture_active: false,
+        }
+    }
 
     #[test]
     fn pending_indicator_visible_only_for_pending_promptless_capture() {
@@ -92,6 +132,30 @@ mod tests {
         assert!(pending_indicator_visible(false, &action));
         assert!(!pending_indicator_visible(true, &action));
         assert!(!pending_indicator_visible(false, &None));
+    }
+
+    #[test]
+    fn start_pending_capture_sets_pending_capture_action() {
+        let mut app = test_app();
+        let action = PendingCaptureAction::ForceRecaptureWindow {
+            workspace_index: 1,
+            window_index: 2,
+        };
+
+        app.start_pending_capture(action.clone());
+
+        assert_eq!(app.pending_capture_action, Some(action));
+    }
+
+    #[test]
+    fn cancel_pending_capture_clears_pending_capture_action() {
+        let mut app = test_app();
+        app.pending_capture_action =
+            Some(PendingCaptureAction::CaptureActiveWindow { workspace_index: 3 });
+
+        app.cancel_pending_capture();
+
+        assert_eq!(app.pending_capture_action, None);
     }
 }
 
@@ -317,7 +381,7 @@ impl EframeApp for App {
 impl App {
     pub fn start_pending_capture(&mut self, action: PendingCaptureAction) {
         self.pending_capture_action = Some(action);
-        let _ = poll_recapture_keys();
+        clear_recapture_key_state();
     }
 
     pub fn start_force_recapture(&mut self, workspace_index: usize, window_index: usize) {
@@ -340,7 +404,7 @@ impl App {
 
     pub fn cancel_pending_capture(&mut self) {
         self.pending_capture_action = None;
-        let _ = poll_recapture_keys();
+        clear_recapture_key_state();
     }
 
     pub fn is_waiting_for_manual_capture(&self) -> bool {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -148,4 +148,28 @@ mod tests {
         assert_eq!(loaded.developer_debugging, false);
         assert_eq!(loaded.show_force_recapture_prompt, false);
     }
+
+    #[test]
+    fn missing_force_recapture_prompt_defaults_to_false() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        cleanup();
+        fs::write(
+            "settings.json",
+            r#"{
+  "save_on_exit": false,
+  "auto_save": false,
+  "log_level": "info",
+  "last_layout_file": null,
+  "last_workspace_file": null,
+  "last_bindings_file": null,
+  "developer_debugging": false
+}"#,
+        )
+        .unwrap();
+
+        let loaded = load_settings();
+        cleanup();
+
+        assert_eq!(loaded.show_force_recapture_prompt, false);
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure `show_force_recapture_prompt` is persisted and backwards-compatible when absent from older `settings.json` files. 
- Add unit coverage for the pending-capture helper behavior and state transitions without depending on real Win32 keyboard/window state. 
- Prevent flakiness in unit tests caused by global keyboard polling by introducing a test-only seam.

### Description
- Updated `src/settings.rs` tests: `round_trip_true` and `round_trip_false` now include `show_force_recapture_prompt` and assert loaded values, and added `missing_force_recapture_prompt_defaults_to_false` which writes an old-format `settings.json` (without the field) and asserts the loaded value is `false`.
- Added unit tests in `src/gui.rs` covering the pure helper `pending_indicator_visible` and two state-transition tests: `start_pending_capture_sets_pending_capture_action` and `cancel_pending_capture_clears_pending_capture_action`, using a lightweight `test_app()` constructor so tests don't depend on a real Win32 active window.
- Introduced a test-only seam `clear_recapture_key_state()` (no-op under `#[cfg(test)]`, calls `poll_recapture_keys()` otherwise) and replaced direct `poll_recapture_keys()` calls in `start_pending_capture` and `cancel_pending_capture` with this seam to avoid polling global keyboard state during tests.

### Testing
- Ran `cargo fmt` and `git diff --check` locally (formatting and diff checks applied). 
- Attempted `cargo test settings` on the default toolchain which failed due to the local `rustc 1.87.0` being older than an upstream dependency requirement (`image` needs `1.88.0`).
- Attempted `cargo +1.88.0 test settings` / `cargo +1.88.0 test pending` and full `cargo +1.88.0 test` on the Linux host which failed to compile because the crate uses Windows-only APIs from the `windows` crate on a non-Windows target.
- Attempted cross-target `cargo +1.88.0 test settings --target x86_64-pc-windows-gnu` but the build failed due to missing cross toolchain component (`x86_64-w64-mingw32-dlltool`).
- Summary: new tests and the seam are in place and compile in theory, but running the Windows-specific unit tests was blocked by toolchain and target environment limitations in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24c5d54e80833291f8ec724b72b46d)